### PR TITLE
HttpServer: Fix IsAvailable() to be able to return FALSE

### DIFF
--- a/src/HttpMock.Unit.Tests/HttpMock.Unit.Tests.csproj
+++ b/src/HttpMock.Unit.Tests/HttpMock.Unit.Tests.csproj
@@ -55,6 +55,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EndpointMatchingRuleTests.cs" />
+    <Compile Include="HttpServerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RequestHandlerTests.cs" />
     <Compile Include="RequestProcessorTests.cs" />

--- a/src/HttpMock.Unit.Tests/HttpServerTests.cs
+++ b/src/HttpMock.Unit.Tests/HttpServerTests.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using HttpMock;
+using NUnit.Framework;
+
+namespace SevenDigital.HttpMock.Unit.Tests
+{
+	[TestFixture]
+	public class HttpServerTests
+	{
+		[Test]
+		public void IsAvailableReturnsFalseIfStartNotCalled()
+		{
+			IHttpServer httpServer = new HttpServer(new Uri("http://localhost:9099"));
+			Assert.That(httpServer.IsAvailable(), Is.EqualTo(false));
+		}
+	}
+}

--- a/src/HttpMock/HttpServer.cs
+++ b/src/HttpMock/HttpServer.cs
@@ -41,10 +41,11 @@ namespace HttpMock
 			int attempts = 0;
 			using (var tcpClient = new TcpClient()) {
 				while (attempts < timesToWait) {
-					tcpClient.Connect(_uri.Host, _uri.Port);
-					if (tcpClient.Connected) {
-						return true;
-					}
+					try {
+						tcpClient.Connect(_uri.Host, _uri.Port);
+						return tcpClient.Connected;
+					} catch (SocketException) {}
+
 					Thread.Sleep(100);
 					attempts++;
 				}


### PR DESCRIPTION
If the method .Start() of HttpServer was not called, IsAvailable() was
throwing an exception instead of returning FALSE.

This change has the added benefit that improves HttpMock a lot when run
with Mono. Why? Because apparently the _thread.Start(); in Microsoft.NET
is very fast and IsAvailable always was queried AFTER the server thread
had already started Kayak. In Mono, this fast is not so fast, so then
IsAvailable was throwing the exception and not using the retrying loop
(that is already in place) properly.

This is not a Mono bug. When using multi-threading code, you should never
assume any certain speed of any thread.
