### PR TITLE
HttpServerTests: don't use a certain port to test, but find an available one

### DIFF
--- a/src/HttpMock.Unit.Tests/HttpMock.Unit.Tests.csproj
+++ b/src/HttpMock.Unit.Tests/HttpMock.Unit.Tests.csproj
@@ -56,6 +56,7 @@
   <ItemGroup>
     <Compile Include="EndpointMatchingRuleTests.cs" />
     <Compile Include="HttpServerTests.cs" />
+    <Compile Include="PortHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RequestHandlerTests.cs" />
     <Compile Include="RequestProcessorTests.cs" />

--- a/src/HttpMock.Unit.Tests/HttpServerTests.cs
+++ b/src/HttpMock.Unit.Tests/HttpServerTests.cs
@@ -9,7 +9,8 @@ namespace HttpMock.Unit.Tests
 		[Test]
 		public void IsAvailableReturnsFalseIfStartNotCalled()
 		{
-			IHttpServer httpServer = new HttpServer(new Uri("http://localhost:9099"));
+			IHttpServer httpServer = new HttpServer(new Uri(String.Format("http://localhost:{0}",
+															              PortHelper.FindLocalAvailablePortForTesting())));
 			Assert.That(httpServer.IsAvailable(), Is.EqualTo(false));
 		}
 	}

--- a/src/HttpMock.Unit.Tests/PortHelper.cs
+++ b/src/HttpMock.Unit.Tests/PortHelper.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Security;
+
+namespace HttpMock.Unit.Tests
+{
+	internal static class PortHelper
+	{
+		internal static int FindLocalAvailablePortForTesting ()
+		{
+			for (var i = 1025; i <= 65000; i++)
+			{
+				using (var tcpClient = new TcpClient())
+				{
+					bool connected = false;
+					try
+					{
+						tcpClient.Connect(IPAddress.Loopback, i);
+						connected = tcpClient.Connected;
+					}
+					catch (SocketException) { }
+
+					if (!connected)
+						return i;
+				}
+			}
+			throw new HostProtectionException("localhost seems to have ALL ports open, are you mad?");
+		}
+	}
+}


### PR DESCRIPTION
This is because that port may be in use by something else in the host
where the tests run (internally in 7d this was failing in buildagent009
but not in buildagent001!).
