### PR TITLE
Fix for null ref error when query string has a trailing ampersand

### DIFF
--- a/src/HttpMock.Unit.Tests/EndpointMatchingRuleTests.cs
+++ b/src/HttpMock.Unit.Tests/EndpointMatchingRuleTests.cs
@@ -130,5 +130,21 @@ namespace HttpMock.Unit.Tests
 			var endpointMatchingRule = new EndpointMatchingRule();
 			Assert.That(endpointMatchingRule.IsEndpointMatch(requestHandler, httpRequestHead));
 		}
+
+		[Test]
+		public void should_match_when_the_query_string_has_a_trailing_ampersand()
+		{
+
+			var requestHandler = MockRepository.GenerateStub<IRequestHandler>();
+			requestHandler.Path = "test";
+			requestHandler.Method = "GET";
+			requestHandler.QueryParams = new Dictionary<string, string> { { "a", "b" } ,{"c","d"}};
+
+			var httpRequestHead = new HttpRequestHead { Uri = "test?a=b&c=d&", Method = "GET" };
+
+			var endpointMatchingRule = new EndpointMatchingRule();
+			Assert.That(endpointMatchingRule.IsEndpointMatch(requestHandler, httpRequestHead));
+			
+		}
 	}
 }

--- a/src/HttpMock/EndpointMatchingRule.cs
+++ b/src/HttpMock/EndpointMatchingRule.cs
@@ -36,7 +36,9 @@ namespace HttpMock
 
 			string queryString = request.Uri.Substring(positionOfQueryStart);
 			NameValueCollection valueCollection = HttpUtility.ParseQueryString(queryString);
-			var requestQueryParams = valueCollection.AllKeys.ToDictionary(k => k, k => valueCollection[k]);
+			var requestQueryParams = valueCollection.AllKeys
+				.Where(k => !string.IsNullOrEmpty(k))
+				.ToDictionary(k => k, k => valueCollection[k]);
 			return requestQueryParams;
 		}
 	}


### PR DESCRIPTION
When the query string has an trailing ampersand, the Endpointmatching rule was throwing a  Null ref error.
