### PR TITLE
Assertion for query parameters

### DIFF
--- a/src/HttpMock.Unit.Tests/EndpointMatchingRuleTests.cs
+++ b/src/HttpMock.Unit.Tests/EndpointMatchingRuleTests.cs
@@ -54,7 +54,7 @@ namespace HttpMock.Unit.Tests
 		}
 
 		[Test]
-		public void urls_and_methods_match_queryparams_differ_it_returns_false() {
+		public void urls_and_methods_match_queryparams_differ_it_returns_true() {
 			var requestHandler = MockRepository.GenerateStub<IRequestHandler>();
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
@@ -62,7 +62,7 @@ namespace HttpMock.Unit.Tests
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test", Method = "GET" };
 			var endpointMatchingRule = new EndpointMatchingRule();
-			Assert.That(endpointMatchingRule.IsEndpointMatch(requestHandler, httpRequestHead), Is.False);
+			Assert.That(endpointMatchingRule.IsEndpointMatch(requestHandler, httpRequestHead), Is.True);
 		}
 
 		[Test]
@@ -78,7 +78,7 @@ namespace HttpMock.Unit.Tests
 		}
 
 		[Test]
-		public void urls_and_methods_match_and_queryparams_does_not_exist_it_returns_false() {
+		public void urls_and_methods_match_and_queryparams_does_not_exist_it_returns_true() {
 			var requestHandler = MockRepository.GenerateStub<IRequestHandler>();
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
@@ -86,7 +86,7 @@ namespace HttpMock.Unit.Tests
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test?oauth_consumer_key=test-api&elvis=alive&moonlandings=faked", Method = "GET" };
 			var endpointMatchingRule = new EndpointMatchingRule();
-			Assert.That(endpointMatchingRule.IsEndpointMatch(requestHandler, httpRequestHead), Is.False);
+			Assert.That(endpointMatchingRule.IsEndpointMatch(requestHandler, httpRequestHead), Is.True);
 		}
 
 

--- a/src/HttpMock.Unit.Tests/RequestProcessorTests.cs
+++ b/src/HttpMock.Unit.Tests/RequestProcessorTests.cs
@@ -115,10 +115,9 @@ namespace HttpMock.Unit.Tests {
 
 			Assert.That(handler.Path, Is.EqualTo(expectedPath));
 			Assert.That(handler.Method, Is.EqualTo(expectedMethod));
-
 		}
 
-		[Test]
+        [Test]
 		public void When_a_handler_is_hit_handlers_request_count_is_incremented() {
 
 			string expectedPath = "/blah/test";

--- a/src/HttpMock/EndpointMatchingRule.cs
+++ b/src/HttpMock/EndpointMatchingRule.cs
@@ -14,21 +14,11 @@ namespace HttpMock
 			if (requestHandler.QueryParams == null)
 				throw new ArgumentException("requestHandler QueryParams cannot be null");
 
-			var requestQueryParams = GetQueryParams(request);
-
             bool uriStartsWith = MatchPath(requestHandler, request);
-            
 
 			bool httpMethodsMatch = requestHandler.Method == request.Method;
 			
-			bool queryParamMatch = true;
-			bool shouldMatchQueryParams = (requestHandler.QueryParams.Count > 0);
-			
-			if (shouldMatchQueryParams) {
-				queryParamMatch = new QueryParamMatch().MatchQueryParams(requestHandler, requestQueryParams);
-			}
-
-			return uriStartsWith && httpMethodsMatch && queryParamMatch;
+			return uriStartsWith && httpMethodsMatch;
 		}
 
 	    private static bool MatchPath(IRequestHandler requestHandler, HttpRequestHead request)

--- a/src/HttpMock/Extensions.cs
+++ b/src/HttpMock/Extensions.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace HttpMock
+{
+    public static class DictionaryExtensionMethods
+    {
+        public static bool ContentEquals<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, IDictionary<TKey, TValue> otherDictionary)
+        {
+            dictionary = dictionary ?? new Dictionary<TKey, TValue>();
+            otherDictionary = otherDictionary ?? new Dictionary<TKey, TValue>();
+
+            return otherDictionary.OrderBy(kvp => kvp.Key)
+                .SequenceEqual(dictionary.OrderBy(kvp => kvp.Key));
+        }
+    }
+}

--- a/src/HttpMock/HttpMock.csproj
+++ b/src/HttpMock/HttpMock.csproj
@@ -53,6 +53,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions.cs" />
     <Compile Include="IRequestVerify.cs" />
     <Compile Include="RequestMatcher.cs" />
     <Compile Include="ReceivedRequest.cs" />

--- a/src/HttpMock/RequestHandlerExpectExtensions.cs
+++ b/src/HttpMock/RequestHandlerExpectExtensions.cs
@@ -1,4 +1,7 @@
 ﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
 
@@ -28,5 +31,17 @@ namespace HttpMock
 			Assert.That(headerValue, Is.Not.Null, "Request did not contain a header '{0}'", header);
 			Assert.That(headerValue, match);
 		}
-	}
+
+        public static void WithParams(this IRequestVerify handler, IDictionary<string, string> expectedQueryParameters)
+        {
+            var queryParamsString = handler.LastRequest().RequestHead.QueryString;
+            
+            Assert.That(queryParamsString, Is.Not.Null, "Request did not contain query parameters");
+
+            var queryParams = queryParamsString.Split('&').ToList()
+                .Select(s => s.Split('='))
+                .ToDictionary(key => key[0].Trim(), value => value[1].Trim());
+            Assert.IsTrue(queryParams.ContentEquals(expectedQueryParameters), "The query parameters {0} do not match the expected ones {1}", queryParams, expectedQueryParameters);
+        }
+    }
 }

--- a/src/HttpMock/RequestProcessor.cs
+++ b/src/HttpMock/RequestProcessor.cs
@@ -81,11 +81,16 @@ namespace HttpMock
 			return _handlers.Count();
 		}
 
-	    public IRequestVerify FindHandler(string method, string path) {
-			return (IRequestVerify) _handlers.Where(x => x.Path == path && x.Method == method).FirstOrDefault();
-		}
+	    public IRequestVerify FindHandler(string method, string path)
+        {
+            _log.DebugFormat("M1keeee {0}|{1}", method, path);
+            path = path.Split('?').First();
+            
+            return (IRequestVerify)_handlers
+                .FirstOrDefault(x => x.Path == path && x.Method == method/* && x.QueryParams.ContentEquals(queryParams)*/);
+        }
 
-		private static string DumpQueryParams(IDictionary<string, string> queryParams) {
+        private static string DumpQueryParams(IDictionary<string, string> queryParams) {
 			var sb = new StringBuilder();
 			foreach (var param in queryParams) {
 				sb.AppendFormat("{0}={1}&", param.Key, param.Value);

--- a/src/HttpMock/RequestProcessor.cs
+++ b/src/HttpMock/RequestProcessor.cs
@@ -83,9 +83,6 @@ namespace HttpMock
 
 	    public IRequestVerify FindHandler(string method, string path)
         {
-            _log.DebugFormat("M1keeee {0}|{1}", method, path);
-            path = path.Split('?').First();
-            
             return (IRequestVerify)_handlers
                 .FirstOrDefault(x => x.Path == path && x.Method == method/* && x.QueryParams.ContentEquals(queryParams)*/);
         }

--- a/src/HttpMock/RequestProcessor.cs
+++ b/src/HttpMock/RequestProcessor.cs
@@ -84,7 +84,7 @@ namespace HttpMock
 	    public IRequestVerify FindHandler(string method, string path)
         {
             return (IRequestVerify)_handlers
-                .FirstOrDefault(x => x.Path == path && x.Method == method/* && x.QueryParams.ContentEquals(queryParams)*/);
+                .FirstOrDefault(x => x.Path == path && x.Method == method);
         }
 
         private static string DumpQueryParams(IDictionary<string, string> queryParams) {

--- a/src/HttpMock/RequestWasCalled.cs
+++ b/src/HttpMock/RequestWasCalled.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using NUnit.Framework;
 
 namespace HttpMock
@@ -15,8 +16,9 @@ namespace HttpMock
 			return AssertHandler("GET", path);
 		}
 
-		private IRequestVerify AssertHandler(string method, string path) {
-			var handler = _requestProcessor.FindHandler(method, path);
+		private IRequestVerify AssertHandler(string method, string path)
+		{
+		    var handler = _requestProcessor.FindHandler(method, path);
 			Assert.That(handler, Is.Not.Null, string.Format("Handler for path {0} and method {1} was not stubbed", path, method));
 			Assert.That(handler.RequestCount(), Is.GreaterThan(0), string.Format("Handler for path {0} and method {1} was never called", path, method));
 			return handler;

--- a/src/HttpMock/RequestWasNotCalled.cs
+++ b/src/HttpMock/RequestWasNotCalled.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using NUnit.Framework;
 
 namespace HttpMock
@@ -15,8 +16,9 @@ namespace HttpMock
 			return AssertHandler( "GET", path);
 		}
 
-		private IRequestVerify AssertHandler(string method, string path) {
-			var handler = _requestProcessor.FindHandler(method, path);
+		private IRequestVerify AssertHandler(string method, string path)
+		{
+		    var handler = _requestProcessor.FindHandler(method, path);
 			if (handler != null) {
 				Assert.That(handler.RequestCount(), Is.EqualTo(0), "Expected not to find a request for {1}{0} but was found", method, path);
 			}else {


### PR DESCRIPTION
Hi, 

We have been using your library here at Audionetwork for our integration tests and we found it hard to write tests that asserted the query parameters. If we added them to the string in the form of "?a=b&c=d" in the AssertWasCalled(), we got an error that the path was never stubbed because the RequestProcessor.FindHandler() did not parse the path to strip it from the query params. 

So, instead of doing this parsing, we decided to treat the query params like the body and headers of the request. We added another RequestHandlerExpectExtensions method, the WithParams() to be called after the AssertWasCalled().

Please review the changes and let me know if you have any questions or remarks. Especially about _where_ I decided to put everything and if the test coverage is right. 

Thank you,
Michael Tomaras