### PR TITLE
New method GetRequestAt added to RequestHandler class

### DIFF
--- a/src/HttpMock.Integration.Tests/HttpEndPointTests.cs
+++ b/src/HttpMock.Integration.Tests/HttpEndPointTests.cs
@@ -9,34 +9,34 @@ using System.Collections.Generic;
 
 namespace HttpMock.Integration.Tests
 {
-	[TestFixture]
-	public class HttpEndPointTests
-	{
-		private IHttpServer _stubHttp;
-		private string _hostUrl;
+    [TestFixture]
+    public class HttpEndPointTests
+    {
+        private IHttpServer _stubHttp;
+        private string _hostUrl;
 
-		[SetUp]
-		public void SetUp()
-		{
-			_hostUrl = HostHelper.GenerateAHostUrlForAStubServer();
-		}
+        [SetUp]
+        public void SetUp()
+        {
+            _hostUrl = HostHelper.GenerateAHostUrlForAStubServer();
+        }
 
-		[Test]
-		public void SUT_should_return_stubbed_response()
-		{
-			_stubHttp = HttpMockRepository.At(_hostUrl);
+        [Test]
+        public void SUT_should_return_stubbed_response()
+        {
+            _stubHttp = HttpMockRepository.At(_hostUrl);
 
-			const string expected = "<xml><>response>Hello World</response></xml>";
-			_stubHttp.Stub(x => x.Get("/endpoint"))
-				.Return(expected)
-				.OK();
+            const string expected = "<xml><>response>Hello World</response></xml>";
+            _stubHttp.Stub(x => x.Get("/endpoint"))
+                .Return(expected)
+                .OK();
 
 
 
-			string result = new WebClient().DownloadString(string.Format("{0}/endpoint", _hostUrl));
+            string result = new WebClient().DownloadString(string.Format("{0}/endpoint", _hostUrl));
 
-			Assert.That(result, Is.EqualTo(expected));
-		}
+            Assert.That(result, Is.EqualTo(expected));
+        }
 
         [TestCase(1)]
         [TestCase(100)]
@@ -50,7 +50,7 @@ namespace HttpMock.Integration.Tests
 
             requestHandler.Return(expected).OK();
 
-            
+
 
             using (var wc = new WebClient())
             {
@@ -65,7 +65,7 @@ namespace HttpMock.Integration.Tests
         [TestCase(1)]
         [TestCase(10)]
         [TestCase(50)]
-        public void SUT_should_get_back_exact_content_in_the_nth_request_body(int count)
+        public void SUT_should_get_back_the_collection_of_requests(int count)
         {
             _stubHttp = HttpMockRepository.At(_hostUrl);
 
@@ -73,7 +73,7 @@ namespace HttpMock.Integration.Tests
 
             requestHandlerStub.Return(string.Empty).OK();
 
-            var expectedList = new List<string>();
+            var expectedBodyList = new Queue<string>();
             using (var wc = new WebClient())
             {
                 wc.Headers[HttpRequestHeader.ContentType] = "application/xml";
@@ -81,207 +81,210 @@ namespace HttpMock.Integration.Tests
                 {
                     string expected = string.Format("<xml><>response>{0}</response></xml>", string.Join(" ", Enumerable.Range(0, i)));
                     wc.UploadString(string.Format("{0}/endpoint", _hostUrl), expected);
-                    expectedList.Add(expected);
+                    expectedBodyList.Enqueue(expected);
                 }
             }
 
             var requestHandler = (RequestHandler)requestHandlerStub;
-            for (int i = 0; i < count; i++)
+
+            var observedRequests = requestHandler.GetObservedRequests();
+            Assert.AreEqual(expectedBodyList.Count, observedRequests.Count);
+
+            for (int i = 0; i < observedRequests.Count; i++)
             {
-                var requestBody = requestHandler.GetRequestAt(i).Body;
-                Assert.That(requestBody, Is.EqualTo(expectedList[i]));
+                Assert.AreEqual(expectedBodyList.ElementAt(i), observedRequests.ElementAt(i).Body);
             }
         }
 
 
         [Test]
-		public void Should_start_listening_before_stubs_have_been_set()
-		{
-			_stubHttp = HttpMockRepository.At(_hostUrl);
+        public void Should_start_listening_before_stubs_have_been_set()
+        {
+            _stubHttp = HttpMockRepository.At(_hostUrl);
 
-			_stubHttp.Stub(x => x.Get("/endpoint"))
-				.Return("listening")
-				.OK();
+            _stubHttp.Stub(x => x.Get("/endpoint"))
+                .Return("listening")
+                .OK();
 
-			using (var tcpClient = new TcpClient())
-			{
-				var uri = new Uri(_hostUrl);
+            using (var tcpClient = new TcpClient())
+            {
+                var uri = new Uri(_hostUrl);
 
-				tcpClient.Connect(uri.Host, uri.Port);
+                tcpClient.Connect(uri.Host, uri.Port);
 
-				Assert.That(tcpClient.Connected, Is.True);
+                Assert.That(tcpClient.Connected, Is.True);
 
-				tcpClient.Close();
-			}
+                tcpClient.Close();
+            }
 
-			string result = new WebClient().DownloadString(string.Format("{0}/endpoint", _hostUrl));
+            string result = new WebClient().DownloadString(string.Format("{0}/endpoint", _hostUrl));
 
-			Assert.That(result, Is.EqualTo("listening"));
-		}
+            Assert.That(result, Is.EqualTo("listening"));
+        }
 
-		[Test]
-		public void Should_return_expected_ok_response()
-		{
-			_stubHttp = HttpMockRepository.At(_hostUrl);
+        [Test]
+        public void Should_return_expected_ok_response()
+        {
+            _stubHttp = HttpMockRepository.At(_hostUrl);
 
-			_stubHttp
-				.Stub(x => x.Get("/api2/status"))
-				.Return("Hello")
-				.OK();
+            _stubHttp
+                .Stub(x => x.Get("/api2/status"))
+                .Return("Hello")
+                .OK();
 
-			_stubHttp
-				.Stub(x => x.Get("/api2/echo"))
-				.Return("Echo")
-				.NotFound();
+            _stubHttp
+                .Stub(x => x.Get("/api2/echo"))
+                .Return("Echo")
+                .NotFound();
 
-			_stubHttp
-				.Stub(x => x.Get("/api2/echo2"))
-				.Return("Nothing")
-				.WithStatus(HttpStatusCode.Unauthorized);
-
-
-
-			var wc = new WebClient();
-
-			Assert.That(wc.DownloadString(string.Format("{0}/api2/status", _hostUrl)), Is.EqualTo("Hello"));
-
-			try
-			{
-				Console.WriteLine(wc.DownloadString(_hostUrl + "/api2/echo"));
-			}
-			catch (Exception ex)
-			{
-				Assert.That(ex, Is.InstanceOf(typeof (WebException)));
-				Assert.That(((WebException) ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
-			}
-
-			try
-			{
-				wc.DownloadString(_hostUrl + "/api2/echo2");
-			}
-			catch (Exception ex)
-			{
-				Assert.That(ex, Is.InstanceOf(typeof (WebException)));
-				Assert.That(((WebException) ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
-			}
-		}
-
-
-		[Test]
-		public void Should_hit_the_same_url_multiple_times()
-		{
-			string endpoint = _hostUrl;
-			_stubHttp = HttpMockRepository.At(endpoint);
-
-
-			_stubHttp
-				.Stub(x => x.Get("/api2/echo"))
-				.Return("Echo")
-				.NotFound();
-
-			_stubHttp
-				.Stub(x => x.Get("/api2/echo2"))
-				.Return("Nothing")
-				.WithStatus(HttpStatusCode.Unauthorized);
+            _stubHttp
+                .Stub(x => x.Get("/api2/echo2"))
+                .Return("Nothing")
+                .WithStatus(HttpStatusCode.Unauthorized);
 
 
 
-			for (int count = 0; count < 6; count++)
-			{
-				RequestEcho(endpoint);
-			}
-		}
+            var wc = new WebClient();
 
-		[Test]
-		public void Should_support_range_requests()
-		{
-			_stubHttp = HttpMockRepository.At(_hostUrl);
-			string query = "/path/file";
-			int fileSize = 2048;
-			string pathToFile = CreateFile(fileSize);
+            Assert.That(wc.DownloadString(string.Format("{0}/api2/status", _hostUrl)), Is.EqualTo("Hello"));
 
-			try
-			{
-				_stubHttp.Stub(x => x.Get(query))
-					.ReturnFileRange(pathToFile, 0, 1023)
-					.WithStatus(HttpStatusCode.PartialContent);
+            try
+            {
+                Console.WriteLine(wc.DownloadString(_hostUrl + "/api2/echo"));
+            }
+            catch (Exception ex)
+            {
+                Assert.That(ex, Is.InstanceOf(typeof(WebException)));
+                Assert.That(((WebException)ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
+            }
+
+            try
+            {
+                wc.DownloadString(_hostUrl + "/api2/echo2");
+            }
+            catch (Exception ex)
+            {
+                Assert.That(ex, Is.InstanceOf(typeof(WebException)));
+                Assert.That(((WebException)ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
+            }
+        }
 
 
+        [Test]
+        public void Should_hit_the_same_url_multiple_times()
+        {
+            string endpoint = _hostUrl;
+            _stubHttp = HttpMockRepository.At(endpoint);
 
-				HttpWebRequest request = (HttpWebRequest) HttpWebRequest.Create(_hostUrl + query);
-				request.Method = "GET";
-				request.AddRange(0, 1023);
-				HttpWebResponse response = (HttpWebResponse) request.GetResponse();
-				byte[] downloadData = new byte[response.ContentLength];
-				using (response)
-				{
-					response.GetResponseStream().Read(downloadData, 0, downloadData.Length);
-				}
-				Assert.That(downloadData.Length, Is.EqualTo(1024));
-			}
-			finally
-			{
-				try
-				{
-					File.Delete(pathToFile);
-				}
-				catch
-				{
-				}
-			}
-		}
 
-		[Test]
-		public void SUT_should_return_stubbed_response_for_custom_verbs()
-		{
-			_stubHttp = HttpMockRepository.At(_hostUrl);
+            _stubHttp
+                .Stub(x => x.Get("/api2/echo"))
+                .Return("Echo")
+                .NotFound();
 
-			const string expected = "<xml><>response>Hello World</response></xml>";
-			_stubHttp.Stub(x => x.CustomVerb("/endpoint", "PURGE"))
-				.Return(expected)
-				.OK();
+            _stubHttp
+                .Stub(x => x.Get("/api2/echo2"))
+                .Return("Nothing")
+                .WithStatus(HttpStatusCode.Unauthorized);
 
 
 
-			var request = (HttpWebRequest) WebRequest.Create(string.Format("{0}/endpoint", _hostUrl));
-			request.Method = "PURGE";
-			request.Host = "nonstandard.host";
-			request.Headers.Add("X-Go-Faster", "11");
-			using (var response = request.GetResponse())
-			using (var stream = response.GetResponseStream())
-			{
-				var responseBody = new StreamReader(stream).ReadToEnd();
-				Assert.That(responseBody, Is.EqualTo(expected));
-			}
-		}
+            for (int count = 0; count < 6; count++)
+            {
+                RequestEcho(endpoint);
+            }
+        }
 
-		private string CreateFile(int fileSize)
-		{
-			string fileName = Path.GetTempFileName();
-			using (FileStream fileStream = File.OpenWrite(fileName))
-			{
-				for (int count = 0; count < fileSize; count++)
-				{
-					fileStream.WriteByte((byte) count);
-				}
-				fileStream.Close();
-			}
-			return fileName;
-		}
+        [Test]
+        public void Should_support_range_requests()
+        {
+            _stubHttp = HttpMockRepository.At(_hostUrl);
+            string query = "/path/file";
+            int fileSize = 2048;
+            string pathToFile = CreateFile(fileSize);
 
-		private static void RequestEcho(string endpoint)
-		{
-			var wc = new WebClient();
+            try
+            {
+                _stubHttp.Stub(x => x.Get(query))
+                    .ReturnFileRange(pathToFile, 0, 1023)
+                    .WithStatus(HttpStatusCode.PartialContent);
 
-			try
-			{
-				wc.DownloadString(endpoint + "/api2/echo");
-			}
-			catch (Exception ex)
-			{
-				Assert.That(ex, Is.InstanceOf(typeof (WebException)));
-				Assert.That(((WebException) ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
-			}
-		}
-	}
+
+
+                HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create(_hostUrl + query);
+                request.Method = "GET";
+                request.AddRange(0, 1023);
+                HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+                byte[] downloadData = new byte[response.ContentLength];
+                using (response)
+                {
+                    response.GetResponseStream().Read(downloadData, 0, downloadData.Length);
+                }
+                Assert.That(downloadData.Length, Is.EqualTo(1024));
+            }
+            finally
+            {
+                try
+                {
+                    File.Delete(pathToFile);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        [Test]
+        public void SUT_should_return_stubbed_response_for_custom_verbs()
+        {
+            _stubHttp = HttpMockRepository.At(_hostUrl);
+
+            const string expected = "<xml><>response>Hello World</response></xml>";
+            _stubHttp.Stub(x => x.CustomVerb("/endpoint", "PURGE"))
+                .Return(expected)
+                .OK();
+
+
+
+            var request = (HttpWebRequest)WebRequest.Create(string.Format("{0}/endpoint", _hostUrl));
+            request.Method = "PURGE";
+            request.Host = "nonstandard.host";
+            request.Headers.Add("X-Go-Faster", "11");
+            using (var response = request.GetResponse())
+            using (var stream = response.GetResponseStream())
+            {
+                var responseBody = new StreamReader(stream).ReadToEnd();
+                Assert.That(responseBody, Is.EqualTo(expected));
+            }
+        }
+
+        private string CreateFile(int fileSize)
+        {
+            string fileName = Path.GetTempFileName();
+            using (FileStream fileStream = File.OpenWrite(fileName))
+            {
+                for (int count = 0; count < fileSize; count++)
+                {
+                    fileStream.WriteByte((byte)count);
+                }
+                fileStream.Close();
+            }
+            return fileName;
+        }
+
+        private static void RequestEcho(string endpoint)
+        {
+            var wc = new WebClient();
+
+            try
+            {
+                wc.DownloadString(endpoint + "/api2/echo");
+            }
+            catch (Exception ex)
+            {
+                Assert.That(ex, Is.InstanceOf(typeof(WebException)));
+                Assert.That(((WebException)ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
+            }
+        }
+    }
 }

--- a/src/HttpMock.Integration.Tests/HttpEndPointTests.cs
+++ b/src/HttpMock.Integration.Tests/HttpEndPointTests.cs
@@ -9,34 +9,34 @@ using System.Collections.Generic;
 
 namespace HttpMock.Integration.Tests
 {
-    [TestFixture]
-    public class HttpEndPointTests
-    {
-        private IHttpServer _stubHttp;
-        private string _hostUrl;
+	[TestFixture]
+	public class HttpEndPointTests
+	{
+		private IHttpServer _stubHttp;
+		private string _hostUrl;
 
-        [SetUp]
-        public void SetUp()
-        {
-            _hostUrl = HostHelper.GenerateAHostUrlForAStubServer();
-        }
+		[SetUp]
+		public void SetUp()
+		{
+			_hostUrl = HostHelper.GenerateAHostUrlForAStubServer();
+		}
 
-        [Test]
-        public void SUT_should_return_stubbed_response()
-        {
-            _stubHttp = HttpMockRepository.At(_hostUrl);
+		[Test]
+		public void SUT_should_return_stubbed_response()
+		{
+			_stubHttp = HttpMockRepository.At(_hostUrl);
 
-            const string expected = "<xml><>response>Hello World</response></xml>";
-            _stubHttp.Stub(x => x.Get("/endpoint"))
-                .Return(expected)
-                .OK();
+			const string expected = "<xml><>response>Hello World</response></xml>";
+			_stubHttp.Stub(x => x.Get("/endpoint"))
+				.Return(expected)
+				.OK();
 
 
 
-            string result = new WebClient().DownloadString(string.Format("{0}/endpoint", _hostUrl));
+			string result = new WebClient().DownloadString(string.Format("{0}/endpoint", _hostUrl));
 
-            Assert.That(result, Is.EqualTo(expected));
-        }
+			Assert.That(result, Is.EqualTo(expected));
+		}
 
         [TestCase(1)]
         [TestCase(100)]
@@ -50,7 +50,7 @@ namespace HttpMock.Integration.Tests
 
             requestHandler.Return(expected).OK();
 
-
+            
 
             using (var wc = new WebClient())
             {
@@ -60,200 +60,200 @@ namespace HttpMock.Integration.Tests
             var requestBody = ((RequestHandler)requestHandler).LastRequest().Body;
 
             Assert.That(requestBody, Is.EqualTo(expected));
-        }
+        }      
 
 
-        [Test]
-        public void Should_start_listening_before_stubs_have_been_set()
-        {
-            _stubHttp = HttpMockRepository.At(_hostUrl);
+		[Test]
+		public void Should_start_listening_before_stubs_have_been_set()
+		{
+			_stubHttp = HttpMockRepository.At(_hostUrl);
 
-            _stubHttp.Stub(x => x.Get("/endpoint"))
-                .Return("listening")
-                .OK();
+			_stubHttp.Stub(x => x.Get("/endpoint"))
+				.Return("listening")
+				.OK();
 
-            using (var tcpClient = new TcpClient())
-            {
-                var uri = new Uri(_hostUrl);
+			using (var tcpClient = new TcpClient())
+			{
+				var uri = new Uri(_hostUrl);
 
-                tcpClient.Connect(uri.Host, uri.Port);
+				tcpClient.Connect(uri.Host, uri.Port);
 
-                Assert.That(tcpClient.Connected, Is.True);
+				Assert.That(tcpClient.Connected, Is.True);
 
-                tcpClient.Close();
-            }
+				tcpClient.Close();
+			}
 
-            string result = new WebClient().DownloadString(string.Format("{0}/endpoint", _hostUrl));
+			string result = new WebClient().DownloadString(string.Format("{0}/endpoint", _hostUrl));
 
-            Assert.That(result, Is.EqualTo("listening"));
-        }
+			Assert.That(result, Is.EqualTo("listening"));
+		}
 
-        [Test]
-        public void Should_return_expected_ok_response()
-        {
-            _stubHttp = HttpMockRepository.At(_hostUrl);
+		[Test]
+		public void Should_return_expected_ok_response()
+		{
+			_stubHttp = HttpMockRepository.At(_hostUrl);
 
-            _stubHttp
-                .Stub(x => x.Get("/api2/status"))
-                .Return("Hello")
-                .OK();
+			_stubHttp
+				.Stub(x => x.Get("/api2/status"))
+				.Return("Hello")
+				.OK();
 
-            _stubHttp
-                .Stub(x => x.Get("/api2/echo"))
-                .Return("Echo")
-                .NotFound();
+			_stubHttp
+				.Stub(x => x.Get("/api2/echo"))
+				.Return("Echo")
+				.NotFound();
 
-            _stubHttp
-                .Stub(x => x.Get("/api2/echo2"))
-                .Return("Nothing")
-                .WithStatus(HttpStatusCode.Unauthorized);
-
-
-
-            var wc = new WebClient();
-
-            Assert.That(wc.DownloadString(string.Format("{0}/api2/status", _hostUrl)), Is.EqualTo("Hello"));
-
-            try
-            {
-                Console.WriteLine(wc.DownloadString(_hostUrl + "/api2/echo"));
-            }
-            catch (Exception ex)
-            {
-                Assert.That(ex, Is.InstanceOf(typeof(WebException)));
-                Assert.That(((WebException)ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
-            }
-
-            try
-            {
-                wc.DownloadString(_hostUrl + "/api2/echo2");
-            }
-            catch (Exception ex)
-            {
-                Assert.That(ex, Is.InstanceOf(typeof(WebException)));
-                Assert.That(((WebException)ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
-            }
-        }
-
-
-        [Test]
-        public void Should_hit_the_same_url_multiple_times()
-        {
-            string endpoint = _hostUrl;
-            _stubHttp = HttpMockRepository.At(endpoint);
-
-
-            _stubHttp
-                .Stub(x => x.Get("/api2/echo"))
-                .Return("Echo")
-                .NotFound();
-
-            _stubHttp
-                .Stub(x => x.Get("/api2/echo2"))
-                .Return("Nothing")
-                .WithStatus(HttpStatusCode.Unauthorized);
+			_stubHttp
+				.Stub(x => x.Get("/api2/echo2"))
+				.Return("Nothing")
+				.WithStatus(HttpStatusCode.Unauthorized);
 
 
 
-            for (int count = 0; count < 6; count++)
-            {
-                RequestEcho(endpoint);
-            }
-        }
+			var wc = new WebClient();
 
-        [Test]
-        public void Should_support_range_requests()
-        {
-            _stubHttp = HttpMockRepository.At(_hostUrl);
-            string query = "/path/file";
-            int fileSize = 2048;
-            string pathToFile = CreateFile(fileSize);
+			Assert.That(wc.DownloadString(string.Format("{0}/api2/status", _hostUrl)), Is.EqualTo("Hello"));
 
-            try
-            {
-                _stubHttp.Stub(x => x.Get(query))
-                    .ReturnFileRange(pathToFile, 0, 1023)
-                    .WithStatus(HttpStatusCode.PartialContent);
+			try
+			{
+				Console.WriteLine(wc.DownloadString(_hostUrl + "/api2/echo"));
+			}
+			catch (Exception ex)
+			{
+				Assert.That(ex, Is.InstanceOf(typeof (WebException)));
+				Assert.That(((WebException) ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
+			}
+
+			try
+			{
+				wc.DownloadString(_hostUrl + "/api2/echo2");
+			}
+			catch (Exception ex)
+			{
+				Assert.That(ex, Is.InstanceOf(typeof (WebException)));
+				Assert.That(((WebException) ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
+			}
+		}
 
 
+		[Test]
+		public void Should_hit_the_same_url_multiple_times()
+		{
+			string endpoint = _hostUrl;
+			_stubHttp = HttpMockRepository.At(endpoint);
 
-                HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create(_hostUrl + query);
-                request.Method = "GET";
-                request.AddRange(0, 1023);
-                HttpWebResponse response = (HttpWebResponse)request.GetResponse();
-                byte[] downloadData = new byte[response.ContentLength];
-                using (response)
-                {
-                    response.GetResponseStream().Read(downloadData, 0, downloadData.Length);
-                }
-                Assert.That(downloadData.Length, Is.EqualTo(1024));
-            }
-            finally
-            {
-                try
-                {
-                    File.Delete(pathToFile);
-                }
-                catch
-                {
-                }
-            }
-        }
 
-        [Test]
-        public void SUT_should_return_stubbed_response_for_custom_verbs()
-        {
-            _stubHttp = HttpMockRepository.At(_hostUrl);
+			_stubHttp
+				.Stub(x => x.Get("/api2/echo"))
+				.Return("Echo")
+				.NotFound();
 
-            const string expected = "<xml><>response>Hello World</response></xml>";
-            _stubHttp.Stub(x => x.CustomVerb("/endpoint", "PURGE"))
-                .Return(expected)
-                .OK();
+			_stubHttp
+				.Stub(x => x.Get("/api2/echo2"))
+				.Return("Nothing")
+				.WithStatus(HttpStatusCode.Unauthorized);
 
 
 
-            var request = (HttpWebRequest)WebRequest.Create(string.Format("{0}/endpoint", _hostUrl));
-            request.Method = "PURGE";
-            request.Host = "nonstandard.host";
-            request.Headers.Add("X-Go-Faster", "11");
-            using (var response = request.GetResponse())
-            using (var stream = response.GetResponseStream())
-            {
-                var responseBody = new StreamReader(stream).ReadToEnd();
-                Assert.That(responseBody, Is.EqualTo(expected));
-            }
-        }
+			for (int count = 0; count < 6; count++)
+			{
+				RequestEcho(endpoint);
+			}
+		}
 
-        private string CreateFile(int fileSize)
-        {
-            string fileName = Path.GetTempFileName();
-            using (FileStream fileStream = File.OpenWrite(fileName))
-            {
-                for (int count = 0; count < fileSize; count++)
-                {
-                    fileStream.WriteByte((byte)count);
-                }
-                fileStream.Close();
-            }
-            return fileName;
-        }
+		[Test]
+		public void Should_support_range_requests()
+		{
+			_stubHttp = HttpMockRepository.At(_hostUrl);
+			string query = "/path/file";
+			int fileSize = 2048;
+			string pathToFile = CreateFile(fileSize);
 
-        private static void RequestEcho(string endpoint)
-        {
-            var wc = new WebClient();
+			try
+			{
+				_stubHttp.Stub(x => x.Get(query))
+					.ReturnFileRange(pathToFile, 0, 1023)
+					.WithStatus(HttpStatusCode.PartialContent);
 
-            try
-            {
-                wc.DownloadString(endpoint + "/api2/echo");
-            }
-            catch (Exception ex)
-            {
-                Assert.That(ex, Is.InstanceOf(typeof(WebException)));
-                Assert.That(((WebException)ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
-            }
-        }
 
-        [TestCase(1)]
+
+				HttpWebRequest request = (HttpWebRequest) HttpWebRequest.Create(_hostUrl + query);
+				request.Method = "GET";
+				request.AddRange(0, 1023);
+				HttpWebResponse response = (HttpWebResponse) request.GetResponse();
+				byte[] downloadData = new byte[response.ContentLength];
+				using (response)
+				{
+					response.GetResponseStream().Read(downloadData, 0, downloadData.Length);
+				}
+				Assert.That(downloadData.Length, Is.EqualTo(1024));
+			}
+			finally
+			{
+				try
+				{
+					File.Delete(pathToFile);
+				}
+				catch
+				{
+				}
+			}
+		}
+
+		[Test]
+		public void SUT_should_return_stubbed_response_for_custom_verbs()
+		{
+			_stubHttp = HttpMockRepository.At(_hostUrl);
+
+			const string expected = "<xml><>response>Hello World</response></xml>";
+			_stubHttp.Stub(x => x.CustomVerb("/endpoint", "PURGE"))
+				.Return(expected)
+				.OK();
+
+
+
+			var request = (HttpWebRequest) WebRequest.Create(string.Format("{0}/endpoint", _hostUrl));
+			request.Method = "PURGE";
+			request.Host = "nonstandard.host";
+			request.Headers.Add("X-Go-Faster", "11");
+			using (var response = request.GetResponse())
+			using (var stream = response.GetResponseStream())
+			{
+				var responseBody = new StreamReader(stream).ReadToEnd();
+				Assert.That(responseBody, Is.EqualTo(expected));
+			}
+		}
+
+		private string CreateFile(int fileSize)
+		{
+			string fileName = Path.GetTempFileName();
+			using (FileStream fileStream = File.OpenWrite(fileName))
+			{
+				for (int count = 0; count < fileSize; count++)
+				{
+					fileStream.WriteByte((byte) count);
+				}
+				fileStream.Close();
+			}
+			return fileName;
+		}
+
+		private static void RequestEcho(string endpoint)
+		{
+			var wc = new WebClient();
+
+			try
+			{
+				wc.DownloadString(endpoint + "/api2/echo");
+			}
+			catch (Exception ex)
+			{
+				Assert.That(ex, Is.InstanceOf(typeof (WebException)));
+				Assert.That(((WebException) ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
+			}
+		}
+		
+		[TestCase(1)]
         [TestCase(10)]
         [TestCase(50)]
         public void SUT_should_get_back_the_collection_of_requests(int count)
@@ -286,5 +286,5 @@ namespace HttpMock.Integration.Tests
                 Assert.AreEqual(expectedBodyList.ElementAt(i), observedRequests.ElementAt(i).Body);
             }
         }
-    }
+	}
 }

--- a/src/HttpMock/IRequestVerify.cs
+++ b/src/HttpMock/IRequestVerify.cs
@@ -1,4 +1,5 @@
 using Kayak.Http;
+using System.Collections.Generic;
 
 namespace HttpMock
 {
@@ -8,5 +9,6 @@ namespace HttpMock
         void RecordRequest(HttpRequestHead request, string body);
         string GetBody();
         ReceivedRequest LastRequest();
+        IEnumerable<ReceivedRequest> GetObservedRequests();
     }
 }

--- a/src/HttpMock/RequestHandler.cs
+++ b/src/HttpMock/RequestHandler.cs
@@ -8,139 +8,123 @@ using Kayak.Http;
 
 namespace HttpMock
 {
-    public class RequestHandler : IRequestHandler, IRequestStub, IRequestVerify
-    {
-        private readonly ResponseBuilder _webResponseBuilder = new ResponseBuilder();
-        private readonly IList<Func<string, bool>> _constraints = new List<Func<string, bool>>();
-        private readonly Queue<ReceivedRequest> _observedRequests = new Queue<ReceivedRequest>();
+	public class RequestHandler : IRequestHandler, IRequestStub, IRequestVerify
+	{
+		private readonly ResponseBuilder _webResponseBuilder = new ResponseBuilder();
+		private readonly IList<Func<string, bool>> _constraints = new List<Func<string, bool>>();
+		private readonly Queue<ReceivedRequest> _observedRequests = new Queue<ReceivedRequest>();
 
-        public RequestHandler(string path, IRequestProcessor requestProcessor)
-        {
-            Path = path;
-            RequestProcessor = requestProcessor;
-            QueryParams = new Dictionary<string, string>();
-        }
+		public RequestHandler(string path, IRequestProcessor requestProcessor) {
+			Path = path;
+			RequestProcessor = requestProcessor;
+			QueryParams = new Dictionary<string, string>();
+		}
 
-        public string Path { get; set; }
-        public string Method { get; set; }
-        public IRequestProcessor RequestProcessor { get; set; }
-        public IDictionary<string, string> QueryParams { get; set; }
+		public string Path { get; set; }
+		public string Method { get; set; }
+		public IRequestProcessor RequestProcessor { get; set; }
+		public IDictionary<string, string> QueryParams { get; set; }
 
-        public ResponseBuilder ResponseBuilder
-        {
-            get { return _webResponseBuilder; }
-        }
+		public ResponseBuilder ResponseBuilder {
+			get { return _webResponseBuilder; }
+		}
 
-        public IRequestStub Return(string responseBody)
-        {
-            _webResponseBuilder.Return(responseBody);
-            return this;
-        }
+		public IRequestStub Return(string responseBody) {
+			_webResponseBuilder.Return(responseBody);
+			return this;
+		}
 
-        public IRequestStub Return(Func<string> responseBody)
-        {
-            _webResponseBuilder.Return(responseBody);
-            return this;
-        }
+		public IRequestStub Return(Func<string> responseBody) {
+			_webResponseBuilder.Return(responseBody);
+			return this;
+		}
 
-        public IRequestStub ReturnFile(string pathToFile)
-        {
-            _webResponseBuilder.WithFile(pathToFile);
+		public IRequestStub ReturnFile(string pathToFile) {
+			_webResponseBuilder.WithFile(pathToFile);
 
-            return this;
-        }
+			return this;
+		}
 
-        public IRequestStub ReturnFileRange(string pathToFile, int from, int to)
-        {
-            _webResponseBuilder.WithFileRange(pathToFile, from, to);
+		public IRequestStub ReturnFileRange(string pathToFile, int from, int to)
+		{
+			_webResponseBuilder.WithFileRange(pathToFile, from, to);
 
-            return this;
-        }
+			return this;
+		}
 
-        public IRequestStub WithParams(IDictionary<string, string> nameValueCollection)
-        {
-            QueryParams = nameValueCollection;
-            return this;
-        }
+		public IRequestStub WithParams(IDictionary<string, string> nameValueCollection) {
+			QueryParams = nameValueCollection;
+			return this;
+		}
 
-        public void OK()
-        {
-            WithStatus(HttpStatusCode.OK);
-        }
+		public void OK() {
+			WithStatus(HttpStatusCode.OK);
+		}
 
-        public void WithStatus(HttpStatusCode httpStatusCode)
-        {
-            ResponseBuilder.WithStatus(httpStatusCode);
-            RequestProcessor.Add(this);
-        }
+		public void WithStatus(HttpStatusCode httpStatusCode) {
+			ResponseBuilder.WithStatus(httpStatusCode);
+			RequestProcessor.Add(this);
+		}
 
-        public void NotFound()
-        {
-            WithStatus(HttpStatusCode.NotFound);
-        }
+		public void NotFound() {
+			WithStatus(HttpStatusCode.NotFound);
+		}
 
-        public IRequestStub AsXmlContent()
-        {
-            return AsContentType("text/xml");
-        }
+		public IRequestStub AsXmlContent() {
+			return AsContentType("text/xml");
+		}
 
-        public IRequestStub AsContentType(string contentType)
-        {
-            ResponseBuilder.WithContentType(contentType);
-            return this;
-        }
+		public IRequestStub AsContentType(string contentType) {
+			ResponseBuilder.WithContentType(contentType);
+			return this;
+		}
 
-        public IRequestStub AddHeader(string header, string headerValue)
-        {
-            ResponseBuilder.AddHeader(header, headerValue);
-            return this;
-        }
+		public IRequestStub AddHeader(string header, string headerValue) {
+			ResponseBuilder.AddHeader(header, headerValue);
+			return this;
+		}
 
-        public IRequestStub WithUrlConstraint(Func<string, bool> constraint)
-        {
-            _constraints.Add(constraint);
-            return this;
-        }
+		public IRequestStub WithUrlConstraint(Func<string, bool> constraint)
+		{
+			_constraints.Add(constraint);
+			return this;
+		}
 
-        public override string ToString()
-        {
-            var sb = new StringBuilder();
-            sb.AppendFormat("{0}:{1}{2}", Path, Method, Environment.NewLine);
-            foreach (var param in QueryParams)
-            {
-                sb.AppendLine(string.Format("{0}:{1}", param.Key, param.Value));
-            }
-            return sb.ToString();
-        }
+		public override string ToString() {
+			var sb = new StringBuilder();
+			sb.AppendFormat("{0}:{1}{2}", Path, Method, Environment.NewLine);
+			foreach (var param in QueryParams) {
+				sb.AppendLine(string.Format("{0}:{1}", param.Key, param.Value));
+			}
+			return sb.ToString();
+		}
 
-        public int RequestCount()
-        {
-            return _observedRequests.Count;
-        }
+		public int RequestCount() {
+			return _observedRequests.Count;
+		}
 
-        public void RecordRequest(HttpRequestHead request, string body)
-        {
-            _observedRequests.Enqueue(new ReceivedRequest(request, body));
-        }
+		public void RecordRequest(HttpRequestHead request, string body)
+		{
+			_observedRequests.Enqueue(new ReceivedRequest(request, body));
+		}
 
-        public string GetBody()
-        {
-            return _observedRequests.Peek().Body;
-        }
+		public string GetBody() {
+			return _observedRequests.Peek().Body;
+		}
 
-        public bool CanVerifyConstraintsFor(string url)
-        {
-            return _constraints.All(c => c(url));
-        }
+		public bool CanVerifyConstraintsFor(string url)
+		{
+			return _constraints.All(c => c(url));
+		}
 
-        public ReceivedRequest LastRequest()
-        {
-            return _observedRequests.Peek();
-        }
-
-        public IEnumerable<ReceivedRequest> GetObservedRequests()
+		public ReceivedRequest LastRequest()
+		{
+			return _observedRequests.Peek();
+		}
+		
+		public IEnumerable<ReceivedRequest> GetObservedRequests()
         {
             return _observedRequests;
         }
-    }
+	}
 }

--- a/src/HttpMock/RequestHandler.cs
+++ b/src/HttpMock/RequestHandler.cs
@@ -110,9 +110,9 @@ namespace HttpMock
 
 		public string GetBody() {
 			return _observedRequests.Peek().Body;
-		}
+        }
 
-		public bool CanVerifyConstraintsFor(string url)
+        public bool CanVerifyConstraintsFor(string url)
 		{
 			return _constraints.All(c => c(url));
 		}
@@ -120,6 +120,10 @@ namespace HttpMock
 		public ReceivedRequest LastRequest()
 		{
 			return _observedRequests.Peek();
+		}
+
+		public ReceivedRequest GetRequestAt(int index){
+			return _observedRequests.ElementAt(index);
 		}
 	}
 }

--- a/src/HttpMock/RequestHandler.cs
+++ b/src/HttpMock/RequestHandler.cs
@@ -122,8 +122,8 @@ namespace HttpMock
 			return _observedRequests.Peek();
 		}
 
-		public ReceivedRequest GetRequestAt(int index){
-			return _observedRequests.ElementAt(index);
+		public Queue<ReceivedRequest> GetObservedRequests(){
+			return _observedRequests;
 		}
 	}
 }

--- a/src/HttpMock/RequestHandler.cs
+++ b/src/HttpMock/RequestHandler.cs
@@ -8,122 +8,139 @@ using Kayak.Http;
 
 namespace HttpMock
 {
-	public class RequestHandler : IRequestHandler, IRequestStub, IRequestVerify
-	{
-		private readonly ResponseBuilder _webResponseBuilder = new ResponseBuilder();
-		private readonly IList<Func<string, bool>> _constraints = new List<Func<string, bool>>();
-		private readonly Queue<ReceivedRequest> _observedRequests = new Queue<ReceivedRequest>();
+    public class RequestHandler : IRequestHandler, IRequestStub, IRequestVerify
+    {
+        private readonly ResponseBuilder _webResponseBuilder = new ResponseBuilder();
+        private readonly IList<Func<string, bool>> _constraints = new List<Func<string, bool>>();
+        private readonly Queue<ReceivedRequest> _observedRequests = new Queue<ReceivedRequest>();
 
-		public RequestHandler(string path, IRequestProcessor requestProcessor) {
-			Path = path;
-			RequestProcessor = requestProcessor;
-			QueryParams = new Dictionary<string, string>();
-		}
+        public RequestHandler(string path, IRequestProcessor requestProcessor)
+        {
+            Path = path;
+            RequestProcessor = requestProcessor;
+            QueryParams = new Dictionary<string, string>();
+        }
 
-		public string Path { get; set; }
-		public string Method { get; set; }
-		public IRequestProcessor RequestProcessor { get; set; }
-		public IDictionary<string, string> QueryParams { get; set; }
+        public string Path { get; set; }
+        public string Method { get; set; }
+        public IRequestProcessor RequestProcessor { get; set; }
+        public IDictionary<string, string> QueryParams { get; set; }
 
-		public ResponseBuilder ResponseBuilder {
-			get { return _webResponseBuilder; }
-		}
+        public ResponseBuilder ResponseBuilder
+        {
+            get { return _webResponseBuilder; }
+        }
 
-		public IRequestStub Return(string responseBody) {
-			_webResponseBuilder.Return(responseBody);
-			return this;
-		}
+        public IRequestStub Return(string responseBody)
+        {
+            _webResponseBuilder.Return(responseBody);
+            return this;
+        }
 
-		public IRequestStub Return(Func<string> responseBody) {
-			_webResponseBuilder.Return(responseBody);
-			return this;
-		}
+        public IRequestStub Return(Func<string> responseBody)
+        {
+            _webResponseBuilder.Return(responseBody);
+            return this;
+        }
 
-		public IRequestStub ReturnFile(string pathToFile) {
-			_webResponseBuilder.WithFile(pathToFile);
+        public IRequestStub ReturnFile(string pathToFile)
+        {
+            _webResponseBuilder.WithFile(pathToFile);
 
-			return this;
-		}
+            return this;
+        }
 
-		public IRequestStub ReturnFileRange(string pathToFile, int from, int to)
-		{
-			_webResponseBuilder.WithFileRange(pathToFile, from, to);
+        public IRequestStub ReturnFileRange(string pathToFile, int from, int to)
+        {
+            _webResponseBuilder.WithFileRange(pathToFile, from, to);
 
-			return this;
-		}
+            return this;
+        }
 
-		public IRequestStub WithParams(IDictionary<string, string> nameValueCollection) {
-			QueryParams = nameValueCollection;
-			return this;
-		}
+        public IRequestStub WithParams(IDictionary<string, string> nameValueCollection)
+        {
+            QueryParams = nameValueCollection;
+            return this;
+        }
 
-		public void OK() {
-			WithStatus(HttpStatusCode.OK);
-		}
+        public void OK()
+        {
+            WithStatus(HttpStatusCode.OK);
+        }
 
-		public void WithStatus(HttpStatusCode httpStatusCode) {
-			ResponseBuilder.WithStatus(httpStatusCode);
-			RequestProcessor.Add(this);
-		}
+        public void WithStatus(HttpStatusCode httpStatusCode)
+        {
+            ResponseBuilder.WithStatus(httpStatusCode);
+            RequestProcessor.Add(this);
+        }
 
-		public void NotFound() {
-			WithStatus(HttpStatusCode.NotFound);
-		}
+        public void NotFound()
+        {
+            WithStatus(HttpStatusCode.NotFound);
+        }
 
-		public IRequestStub AsXmlContent() {
-			return AsContentType("text/xml");
-		}
+        public IRequestStub AsXmlContent()
+        {
+            return AsContentType("text/xml");
+        }
 
-		public IRequestStub AsContentType(string contentType) {
-			ResponseBuilder.WithContentType(contentType);
-			return this;
-		}
+        public IRequestStub AsContentType(string contentType)
+        {
+            ResponseBuilder.WithContentType(contentType);
+            return this;
+        }
 
-		public IRequestStub AddHeader(string header, string headerValue) {
-			ResponseBuilder.AddHeader(header, headerValue);
-			return this;
-		}
+        public IRequestStub AddHeader(string header, string headerValue)
+        {
+            ResponseBuilder.AddHeader(header, headerValue);
+            return this;
+        }
 
-		public IRequestStub WithUrlConstraint(Func<string, bool> constraint)
-		{
-			_constraints.Add(constraint);
-			return this;
-		}
+        public IRequestStub WithUrlConstraint(Func<string, bool> constraint)
+        {
+            _constraints.Add(constraint);
+            return this;
+        }
 
-		public override string ToString() {
-			var sb = new StringBuilder();
-			sb.AppendFormat("{0}:{1}{2}", Path, Method, Environment.NewLine);
-			foreach (var param in QueryParams) {
-				sb.AppendLine(string.Format("{0}:{1}", param.Key, param.Value));
-			}
-			return sb.ToString();
-		}
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.AppendFormat("{0}:{1}{2}", Path, Method, Environment.NewLine);
+            foreach (var param in QueryParams)
+            {
+                sb.AppendLine(string.Format("{0}:{1}", param.Key, param.Value));
+            }
+            return sb.ToString();
+        }
 
-		public int RequestCount() {
-			return _observedRequests.Count;
-		}
+        public int RequestCount()
+        {
+            return _observedRequests.Count;
+        }
 
-		public void RecordRequest(HttpRequestHead request, string body)
-		{
-			_observedRequests.Enqueue(new ReceivedRequest(request, body));
-		}
+        public void RecordRequest(HttpRequestHead request, string body)
+        {
+            _observedRequests.Enqueue(new ReceivedRequest(request, body));
+        }
 
-		public string GetBody() {
-			return _observedRequests.Peek().Body;
+        public string GetBody()
+        {
+            return _observedRequests.Peek().Body;
         }
 
         public bool CanVerifyConstraintsFor(string url)
-		{
-			return _constraints.All(c => c(url));
-		}
+        {
+            return _constraints.All(c => c(url));
+        }
 
-		public ReceivedRequest LastRequest()
-		{
-			return _observedRequests.Peek();
-		}
+        public ReceivedRequest LastRequest()
+        {
+            return _observedRequests.Peek();
+        }
 
-		public Queue<ReceivedRequest> GetObservedRequests(){
-			return _observedRequests;
-		}
-	}
+        public IEnumerable<ReceivedRequest> GetObservedRequests()
+        {
+            return _observedRequests;
+        }
+    }
 }


### PR DESCRIPTION
Addresses issue #64. by giving a `GetRequestAt(int index)` method on `RequestHandler` class.