### PR TITLE
Support matching requests using headers

### DIFF
--- a/src/HttpMock.Integration.Tests/HttpMock.Integration.Tests.csproj
+++ b/src/HttpMock.Integration.Tests/HttpMock.Integration.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="SystemUnderTest.cs" />
     <Compile Include="UsingMultipleServersTests.cs" />
     <Compile Include="UsingTheSameStubServerAndDifferentQueryRequestParams.cs" />
+    <Compile Include="UsingTheSameStubServerAndDifferentRequestHeaders.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="App.config">

--- a/src/HttpMock.Integration.Tests/UsingTheSameStubServerAndDifferentRequestHeaders.cs
+++ b/src/HttpMock.Integration.Tests/UsingTheSameStubServerAndDifferentRequestHeaders.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using NUnit.Framework;
+
+namespace HttpMock.Integration.Tests
+{
+	[TestFixture]
+	public class UsingTheSameStubServerAndDifferentRequestHeaders
+	{
+		private string _endpointToHit;
+		private IHttpServer _httpMockRepository;
+
+		private readonly IDictionary<string, string> _firstSetOfHeaders = new Dictionary<string, string>
+		{
+			{"X-HeaderOne", "one"},
+			{"X-HeaderTwo", "a"}
+		};
+
+		private readonly IDictionary<string, string> _secondSetOfHeaders = new Dictionary<string, string>
+		{
+			{"X-HeaderOne", "one"},
+			{"X-HeaderTwo", "b"}
+		};
+
+		private readonly IDictionary<string, string> _thirdSetOfHeaders = new Dictionary<string, string>
+		{
+			{"X-HeaderOne", "two"},
+			{"X-HeaderTwo", "a"}
+		};
+
+		[SetUp]
+		public void SetUp()
+		{
+			var hostUrl = HostHelper.GenerateAHostUrlForAStubServer();
+			_endpointToHit = hostUrl + "/endpoint";
+			_httpMockRepository = HttpMockRepository.At(hostUrl);
+
+			_httpMockRepository.Stub(x => x.Get("/endpoint"))
+				.WithHeaders(_firstSetOfHeaders)
+				.Return("I was the first one")
+				.OK();
+			_httpMockRepository.Stub(x => x.Get("/endpoint"))
+				.WithHeaders(_secondSetOfHeaders)
+				.Return("I was the second one")
+				.OK();
+			_httpMockRepository.Stub(x => x.Get("/endpoint"))
+				.WithHeaders(_thirdSetOfHeaders)
+				.Return("I was the third one")
+				.OK();
+		}
+
+		[Test]
+		public void Should_return_first_one()
+		{
+			AssertResponse("I was the first one", _firstSetOfHeaders);
+		}
+
+		[Test]
+		public void Should_return_second_one()
+		{
+			AssertResponse("I was the second one", _secondSetOfHeaders);
+		}
+
+		[Test]
+		public void Should_return_third_one()
+		{
+			AssertResponse("I was the third one", _thirdSetOfHeaders);
+		}
+
+		private void AssertResponse(string expected, IEnumerable<KeyValuePair<string, string>> headers)
+		{
+			var webRequest =
+				(HttpWebRequest) WebRequest.Create(string.Format("{0}?abirdinthehand=twointhebush", _endpointToHit));
+			foreach (var header in headers)
+			{
+				webRequest.Headers.Add(header.Key, header.Value);
+			}
+			using (var response = webRequest.GetResponse())
+			{
+				using (var sr = new StreamReader(response.GetResponseStream()))
+				{
+					var readToEnd = sr.ReadToEnd();
+					Assert.That(readToEnd, Is.EqualTo(expected));
+				}
+			}
+		}
+	}
+}

--- a/src/HttpMock.Unit.Tests/EndpointMatchingRuleTests.cs
+++ b/src/HttpMock.Unit.Tests/EndpointMatchingRuleTests.cs
@@ -13,7 +13,6 @@ namespace HttpMock.Unit.Tests
 			var requestHandler = MockRepository.GenerateStub<IRequestHandler>();
 			requestHandler.Path = "test";
 			requestHandler.QueryParams = new Dictionary<string, string>();
-			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test" };
 			var endpointMatchingRule = new EndpointMatchingRule();
@@ -26,7 +25,6 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "PUT";
 			requestHandler.QueryParams = new Dictionary<string, string>();
-			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test", Method = "PUT" };
 			var endpointMatchingRule = new EndpointMatchingRule();
@@ -39,7 +37,6 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string>();
-			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 			var httpRequestHead = new HttpRequestHead { Uri = "test", Method = "PUT" };
 			var endpointMatchingRule = new EndpointMatchingRule();
 			Assert.That(endpointMatchingRule.IsEndpointMatch(requestHandler, httpRequestHead), Is.False);
@@ -51,7 +48,6 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "pest";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string>();
-			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 			var httpRequestHead = new HttpRequestHead { Uri = "test", Method = "GET" };
 			var endpointMatchingRule = new EndpointMatchingRule();
 			Assert.That(endpointMatchingRule.IsEndpointMatch(requestHandler, httpRequestHead), Is.False);
@@ -63,7 +59,6 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string> { { "myParam", "one" } };
-			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test", Method = "GET" };
 			var endpointMatchingRule = new EndpointMatchingRule();
@@ -76,7 +71,6 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string> { { "myParam", "one" } };
-			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test?oauth_consumer_key=test-api&elvis=alive&moonlandings=faked&myParam=one", Method = "GET" };
 			var endpointMatchingRule = new EndpointMatchingRule();
@@ -89,7 +83,6 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string> { { "myParam", "one" } };
-			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test?oauth_consumer_key=test-api&elvis=alive&moonlandings=faked", Method = "GET" };
 			var endpointMatchingRule = new EndpointMatchingRule();
@@ -104,7 +97,6 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string> ();
-			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test?oauth_consumer_key=test-api&elvis=alive&moonlandings=faked", Method = "GET" };
 			var endpointMatchingRule = new EndpointMatchingRule();
@@ -118,7 +110,6 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string>{{"myParam", "one"}};
-			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test?myParam=one", Method = "GET" };
 			
@@ -189,7 +180,6 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string> { { "myParam", "one" } };
-			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test?myParam=OnE", Method = "GET" };
 
@@ -228,7 +218,6 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string> { { "a", "b" } ,{"c","d"}};
-			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test?a=b&c=d&", Method = "GET" };
 
@@ -251,7 +240,6 @@ namespace HttpMock.Unit.Tests
             expectedRequest.Method = "GET";
             expectedRequest.Path = "/path";
             expectedRequest.QueryParams = new Dictionary<string, string>();
-            expectedRequest.RequestHeaders = new Dictionary<string, string>();
             expectedRequest.Stub(s => s.CanVerifyConstraintsFor("")).IgnoreArguments().Return(true);
 
             var requestMatcher = new RequestMatcher(new EndpointMatchingRule());
@@ -275,7 +263,6 @@ namespace HttpMock.Unit.Tests
             expectedRequest.Method = "GET";
             expectedRequest.Path = "/path/specific";
             expectedRequest.QueryParams = new Dictionary<string, string>();
-            expectedRequest.RequestHeaders = new Dictionary<string, string>();
             expectedRequest.Stub(s => s.CanVerifyConstraintsFor("")).IgnoreArguments().Return(true);
 
 
@@ -283,7 +270,6 @@ namespace HttpMock.Unit.Tests
             otherRequest.Method = "GET";
             otherRequest.Path = "/path/";
             otherRequest.QueryParams = new Dictionary<string, string>();
-            otherRequest.RequestHeaders = new Dictionary<string, string>();
             otherRequest.Stub(s => s.CanVerifyConstraintsFor("")).IgnoreArguments().Return(true);
 
             var requestMatcher = new RequestMatcher(new EndpointMatchingRule());

--- a/src/HttpMock.Unit.Tests/EndpointMatchingRuleTests.cs
+++ b/src/HttpMock.Unit.Tests/EndpointMatchingRuleTests.cs
@@ -13,6 +13,7 @@ namespace HttpMock.Unit.Tests
 			var requestHandler = MockRepository.GenerateStub<IRequestHandler>();
 			requestHandler.Path = "test";
 			requestHandler.QueryParams = new Dictionary<string, string>();
+			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test" };
 			var endpointMatchingRule = new EndpointMatchingRule();
@@ -25,6 +26,7 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "PUT";
 			requestHandler.QueryParams = new Dictionary<string, string>();
+			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test", Method = "PUT" };
 			var endpointMatchingRule = new EndpointMatchingRule();
@@ -37,6 +39,7 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string>();
+			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 			var httpRequestHead = new HttpRequestHead { Uri = "test", Method = "PUT" };
 			var endpointMatchingRule = new EndpointMatchingRule();
 			Assert.That(endpointMatchingRule.IsEndpointMatch(requestHandler, httpRequestHead), Is.False);
@@ -48,6 +51,7 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "pest";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string>();
+			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 			var httpRequestHead = new HttpRequestHead { Uri = "test", Method = "GET" };
 			var endpointMatchingRule = new EndpointMatchingRule();
 			Assert.That(endpointMatchingRule.IsEndpointMatch(requestHandler, httpRequestHead), Is.False);
@@ -59,6 +63,7 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string> { { "myParam", "one" } };
+			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test", Method = "GET" };
 			var endpointMatchingRule = new EndpointMatchingRule();
@@ -71,6 +76,7 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string> { { "myParam", "one" } };
+			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test?oauth_consumer_key=test-api&elvis=alive&moonlandings=faked&myParam=one", Method = "GET" };
 			var endpointMatchingRule = new EndpointMatchingRule();
@@ -83,6 +89,7 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string> { { "myParam", "one" } };
+			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test?oauth_consumer_key=test-api&elvis=alive&moonlandings=faked", Method = "GET" };
 			var endpointMatchingRule = new EndpointMatchingRule();
@@ -97,6 +104,7 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string> ();
+			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test?oauth_consumer_key=test-api&elvis=alive&moonlandings=faked", Method = "GET" };
 			var endpointMatchingRule = new EndpointMatchingRule();
@@ -110,11 +118,68 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string>{{"myParam", "one"}};
+			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test?myParam=one", Method = "GET" };
 			
 			var endpointMatchingRule = new EndpointMatchingRule();
 			Assert.That(endpointMatchingRule.IsEndpointMatch(requestHandler, httpRequestHead));
+		}
+
+		[Test]
+		public void urls_and_methods_match_headers_differ_it_returns_false() {
+			var requestHandler = MockRepository.GenerateStub<IRequestHandler>();
+			requestHandler.Path = "test";
+			requestHandler.Method = "GET";
+			requestHandler.QueryParams = new Dictionary<string, string>();
+			requestHandler.RequestHeaders = new Dictionary<string, string> { { "myHeader", "one" } };
+
+			var httpRequestHead = new HttpRequestHead
+			{
+				Uri = "test",
+				Method = "GET",
+				Headers = new Dictionary<string, string>
+				{
+					{ "myHeader", "two" }
+				}
+			};
+			var endpointMatchingRule = new EndpointMatchingRule();
+			Assert.That(endpointMatchingRule.IsEndpointMatch(requestHandler, httpRequestHead), Is.False);
+		}
+
+		[Test]
+		public void urls_and_methods_match_and_headers_match_it_returns_true() {
+			var requestHandler = MockRepository.GenerateStub<IRequestHandler>();
+			requestHandler.Path = "test";
+			requestHandler.Method = "GET";
+			requestHandler.QueryParams = new Dictionary<string, string>();
+			requestHandler.RequestHeaders = new Dictionary<string, string> { { "myHeader", "one" } };
+
+			var httpRequestHead = new HttpRequestHead
+			{
+				Uri = "test",
+				Method = "GET",
+				Headers = new Dictionary<string, string>
+				{
+					{ "myHeader", "one" },
+					{ "anotherHeader", "two" }
+				}
+			};
+			var endpointMatchingRule = new EndpointMatchingRule();
+			Assert.That(endpointMatchingRule.IsEndpointMatch(requestHandler, httpRequestHead));
+		}
+
+		[Test]
+		public void urls_and_methods_match_and_header_does_not_exist_it_returns_false() {
+			var requestHandler = MockRepository.GenerateStub<IRequestHandler>();
+			requestHandler.Path = "test";
+			requestHandler.Method = "GET";
+			requestHandler.QueryParams = new Dictionary<string, string>();
+			requestHandler.RequestHeaders = new Dictionary<string, string> { { "myHeader", "one" } };
+
+			var httpRequestHead = new HttpRequestHead { Uri = "test", Method = "GET" };
+			var endpointMatchingRule = new EndpointMatchingRule();
+			Assert.That(endpointMatchingRule.IsEndpointMatch(requestHandler, httpRequestHead), Is.False);
 		}
 
 		[Test]
@@ -124,8 +189,32 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string> { { "myParam", "one" } };
+			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test?myParam=OnE", Method = "GET" };
+
+			var endpointMatchingRule = new EndpointMatchingRule();
+			Assert.That(endpointMatchingRule.IsEndpointMatch(requestHandler, httpRequestHead));
+		}
+
+		[Test]
+		public void should_do_a_case_insensitive_match_on_header_names_and_values() {
+
+			var requestHandler = MockRepository.GenerateStub<IRequestHandler>();
+			requestHandler.Path = "test";
+			requestHandler.Method = "GET";
+			requestHandler.QueryParams = new Dictionary<string, string>();
+			requestHandler.RequestHeaders = new Dictionary<string, string> { { "myHeader", "one" } };
+
+			var httpRequestHead = new HttpRequestHead
+			{
+				Uri = "test",
+				Method = "GET",
+				Headers = new Dictionary<string, string>
+				{
+					{ "MYheaDER", "OnE" }
+				}
+			};
 
 			var endpointMatchingRule = new EndpointMatchingRule();
 			Assert.That(endpointMatchingRule.IsEndpointMatch(requestHandler, httpRequestHead));
@@ -139,6 +228,7 @@ namespace HttpMock.Unit.Tests
 			requestHandler.Path = "test";
 			requestHandler.Method = "GET";
 			requestHandler.QueryParams = new Dictionary<string, string> { { "a", "b" } ,{"c","d"}};
+			requestHandler.RequestHeaders = new Dictionary<string, string> ();
 
 			var httpRequestHead = new HttpRequestHead { Uri = "test?a=b&c=d&", Method = "GET" };
 
@@ -161,6 +251,7 @@ namespace HttpMock.Unit.Tests
             expectedRequest.Method = "GET";
             expectedRequest.Path = "/path";
             expectedRequest.QueryParams = new Dictionary<string, string>();
+            expectedRequest.RequestHeaders = new Dictionary<string, string>();
             expectedRequest.Stub(s => s.CanVerifyConstraintsFor("")).IgnoreArguments().Return(true);
 
             var requestMatcher = new RequestMatcher(new EndpointMatchingRule());
@@ -184,6 +275,7 @@ namespace HttpMock.Unit.Tests
             expectedRequest.Method = "GET";
             expectedRequest.Path = "/path/specific";
             expectedRequest.QueryParams = new Dictionary<string, string>();
+            expectedRequest.RequestHeaders = new Dictionary<string, string>();
             expectedRequest.Stub(s => s.CanVerifyConstraintsFor("")).IgnoreArguments().Return(true);
 
 
@@ -191,6 +283,7 @@ namespace HttpMock.Unit.Tests
             otherRequest.Method = "GET";
             otherRequest.Path = "/path/";
             otherRequest.QueryParams = new Dictionary<string, string>();
+            otherRequest.RequestHeaders = new Dictionary<string, string>();
             otherRequest.Stub(s => s.CanVerifyConstraintsFor("")).IgnoreArguments().Return(true);
 
             var requestMatcher = new RequestMatcher(new EndpointMatchingRule());

--- a/src/HttpMock/EndpointMatchingRule.cs
+++ b/src/HttpMock/EndpointMatchingRule.cs
@@ -10,6 +10,15 @@ namespace HttpMock
 {
 	public class EndpointMatchingRule : IMatchingRule
 	{
+		private readonly HeaderMatch _headerMatch;
+		private readonly QueryParamMatch _queryParamMatch;
+
+		public EndpointMatchingRule()
+		{
+			_headerMatch = new HeaderMatch();
+			_queryParamMatch = new QueryParamMatch();
+		}
+
 		public bool IsEndpointMatch(IRequestHandler requestHandler, HttpRequestHead request) {
 			if (requestHandler.QueryParams == null)
 				throw new ArgumentException("requestHandler QueryParams cannot be null");
@@ -17,8 +26,7 @@ namespace HttpMock
 			var requestQueryParams = GetQueryParams(request);
 			var requestHeaders = GetHeaders(request);
 
-            bool uriStartsWith = MatchPath(requestHandler, request);
-            
+			bool uriStartsWith = MatchPath(requestHandler, request);
 
 			bool httpMethodsMatch = requestHandler.Method == request.Method;
 			
@@ -26,14 +34,15 @@ namespace HttpMock
 			bool shouldMatchQueryParams = (requestHandler.QueryParams.Count > 0);
 			
 			if (shouldMatchQueryParams) {
-				queryParamMatch = new QueryParamMatch().MatchQueryParams(requestHandler, requestQueryParams);
+				queryParamMatch = _queryParamMatch.MatchQueryParams(requestHandler, requestQueryParams);
 			}
 
 			bool headerMatch = true;
-			bool shouldMatchHeaders = (requestHandler.RequestHeaders.Count > 0);
+			bool shouldMatchHeaders = requestHandler.RequestHeaders != null
+				&& requestHandler.RequestHeaders.Count > 0;
 
 			if (shouldMatchHeaders) {
-				headerMatch = new HeaderMatch().MatchHeaders(requestHandler, requestHeaders);
+				headerMatch = _headerMatch.MatchHeaders(requestHandler, requestHeaders);
 			}
 
 			return uriStartsWith && httpMethodsMatch && queryParamMatch && headerMatch;

--- a/src/HttpMock/EndpointMatchingRule.cs
+++ b/src/HttpMock/EndpointMatchingRule.cs
@@ -15,6 +15,7 @@ namespace HttpMock
 				throw new ArgumentException("requestHandler QueryParams cannot be null");
 
 			var requestQueryParams = GetQueryParams(request);
+			var requestHeaders = GetHeaders(request);
 
             bool uriStartsWith = MatchPath(requestHandler, request);
             
@@ -28,7 +29,14 @@ namespace HttpMock
 				queryParamMatch = new QueryParamMatch().MatchQueryParams(requestHandler, requestQueryParams);
 			}
 
-			return uriStartsWith && httpMethodsMatch && queryParamMatch;
+			bool headerMatch = true;
+			bool shouldMatchHeaders = (requestHandler.RequestHeaders.Count > 0);
+
+			if (shouldMatchHeaders) {
+				headerMatch = new HeaderMatch().MatchHeaders(requestHandler, requestHeaders);
+			}
+
+			return uriStartsWith && httpMethodsMatch && queryParamMatch && headerMatch;
 		}
 
 	    private static bool MatchPath(IRequestHandler requestHandler, HttpRequestHead request)
@@ -59,6 +67,11 @@ namespace HttpMock
 				.Where(k => !string.IsNullOrEmpty(k))
 				.ToDictionary(k => k, k => valueCollection[k]);
 			return requestQueryParams;
+		}
+
+		private static IDictionary<string, string> GetHeaders(HttpRequestHead request)
+		{
+			return request.Headers ?? new Dictionary<string, string>();
 		}
 	}
 }

--- a/src/HttpMock/HeaderMatch.cs
+++ b/src/HttpMock/HeaderMatch.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace HttpMock
+{
+	public class HeaderMatch {
+		internal bool MatchHeaders(IRequestHandler requestHandler, IDictionary<string, string> requestHeaders)
+		{
+			return requestHandler.RequestHeaders.All(
+				expectedHeader => requestHeaders.Any(header => HeadersMatch(expectedHeader, header)));
+		}
+
+		private static bool HeadersMatch(KeyValuePair<string, string> expectedHeader, KeyValuePair<string, string> header)
+		{
+			if (!string.Equals(expectedHeader.Key, header.Key, StringComparison.OrdinalIgnoreCase))
+			{
+				return false;
+			}
+			return string.Equals(expectedHeader.Value, header.Value, StringComparison.OrdinalIgnoreCase);
+		}
+	}
+}

--- a/src/HttpMock/HttpMock.csproj
+++ b/src/HttpMock/HttpMock.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <Compile Include="IRequestProcessor.cs" />
     <Compile Include="IRequestVerify.cs" />
+    <Compile Include="HeaderMatch.cs" />
     <Compile Include="RequestMatcher.cs" />
     <Compile Include="ReceivedRequest.cs" />
     <Compile Include="RequestHandlerFactory.cs" />

--- a/src/HttpMock/IRequestHandler.cs
+++ b/src/HttpMock/IRequestHandler.cs
@@ -8,6 +8,7 @@ namespace HttpMock
 		string Method { get; set; }
 		IRequestProcessor RequestProcessor { get; set; }
 		IDictionary<string, string> QueryParams { get; set; }
+		IDictionary<string, string> RequestHeaders { get; set; }
 		ResponseBuilder ResponseBuilder { get; }
         bool CanVerifyConstraintsFor(string url);
         void RecordRequest(HttpRequestHead request, string body);

--- a/src/HttpMock/IRequestStub.cs
+++ b/src/HttpMock/IRequestStub.cs
@@ -10,6 +10,7 @@ namespace HttpMock
 		IRequestStub Return(Func<string> responseBody);
 		IRequestStub ReturnFile(string pathToFile);
 		IRequestStub WithParams(IDictionary<string, string> nameValueCollection);
+		IRequestStub WithHeaders(IDictionary<string, string> nameValueCollection);
 		void OK();
 		void WithStatus( HttpStatusCode httpStatusCode);
 		void NotFound();

--- a/src/HttpMock/RequestHandler.cs
+++ b/src/HttpMock/RequestHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -18,12 +17,14 @@ namespace HttpMock
 			Path = path;
 			RequestProcessor = requestProcessor;
 			QueryParams = new Dictionary<string, string>();
+			RequestHeaders = new Dictionary<string, string>();
 		}
 
 		public string Path { get; set; }
 		public string Method { get; set; }
 		public IRequestProcessor RequestProcessor { get; set; }
 		public IDictionary<string, string> QueryParams { get; set; }
+		public IDictionary<string, string> RequestHeaders { get; set; }
 
 		public ResponseBuilder ResponseBuilder {
 			get { return _webResponseBuilder; }
@@ -54,6 +55,12 @@ namespace HttpMock
 
 		public IRequestStub WithParams(IDictionary<string, string> nameValueCollection) {
 			QueryParams = nameValueCollection;
+			return this;
+		}
+
+		public IRequestStub WithHeaders(IDictionary<string, string> nameValueCollection)
+		{
+			RequestHeaders = nameValueCollection;
 			return this;
 		}
 


### PR DESCRIPTION
Fixes #71 

I've mostly followed the same approach that is used to match query string parameters.