### PR TITLE
Added byte array overload to Return method and added test

### DIFF
--- a/src/HttpMock.Integration.Tests/HttpEndPointTests.cs
+++ b/src/HttpMock.Integration.Tests/HttpEndPointTests.cs
@@ -3,9 +3,9 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using System.Threading;
 using NUnit.Framework;
 using System.Collections.Generic;
+using System.Text;
 
 namespace HttpMock.Integration.Tests
 {
@@ -34,6 +34,21 @@ namespace HttpMock.Integration.Tests
 
 
 			string result = new WebClient().DownloadString(string.Format("{0}/endpoint", _hostUrl));
+
+			Assert.That(result, Is.EqualTo(expected));
+		}
+
+		[Test]
+		public void SUT_should_return_stubbed_byte_array_response()
+		{
+			_stubHttp = HttpMockRepository.At(_hostUrl);
+
+			byte[] expected = Encoding.UTF8.GetBytes("<xml><>response>Change to bytes to simulate possible stream response</response></xml>");
+			_stubHttp.Stub(x => x.Get("/endpoint"))
+				.Return(expected)
+				.OK();
+
+			byte[] result = new WebClient().DownloadData(string.Format("{0}/endpoint", _hostUrl));
 
 			Assert.That(result, Is.EqualTo(expected));
 		}

--- a/src/HttpMock/IRequestStub.cs
+++ b/src/HttpMock/IRequestStub.cs
@@ -8,6 +8,7 @@ namespace HttpMock
 	{
 		IRequestStub Return(string responseBody);
 		IRequestStub Return(Func<string> responseBody);
+		IRequestStub Return(byte[] responseBody);
 		IRequestStub ReturnFile(string pathToFile);
 		IRequestStub WithParams(IDictionary<string, string> nameValueCollection);
 		IRequestStub WithHeaders(IDictionary<string, string> nameValueCollection);

--- a/src/HttpMock/RequestHandler.cs
+++ b/src/HttpMock/RequestHandler.cs
@@ -40,6 +40,11 @@ namespace HttpMock
 			return this;
 		}
 
+		public IRequestStub Return(byte[] responseBody) {
+			_webResponseBuilder.Return(responseBody);
+			return this;
+		}
+
 		public IRequestStub ReturnFile(string pathToFile) {
 			_webResponseBuilder.WithFile(pathToFile);
 

--- a/src/HttpMock/ResponseBuilder.cs
+++ b/src/HttpMock/ResponseBuilder.cs
@@ -32,6 +32,14 @@ namespace HttpMock
 			return this;
 		}
 
+		public ResponseBuilder Return(byte[] body) {
+			var bufferedBody = new BufferedBody(body);
+			_contentLength = bufferedBody.Length;
+			_response = bufferedBody;
+
+			return this;
+		}
+
 		public IDataProducer BuildBody(IDictionary<string, string> headers) {
 			_response.SetRequestHeaders(headers);
 			return _response;


### PR DESCRIPTION
Added functionality to return byte arrays as well as strings. This will take into account return values that are not just simple strings but rather streams that may be encoded with gzip, for instance.