### PR TITLE
Parallel execution of scenarios with HttpMocks

### DIFF
--- a/src/HttpMock.Integration.Tests/HostHelper.cs
+++ b/src/HttpMock.Integration.Tests/HostHelper.cs
@@ -4,6 +4,8 @@ namespace HttpMock.Integration.Tests
 {
 	internal static class HostHelper
 	{
+        private static object lckObject=new object();
+         
 		public static string GenerateAHostUrlForAStubServerWith(string basePath)
 		{
 			return String.Format("{0}/{1}", GenerateAHostUrlForAStubServer(), basePath);
@@ -12,7 +14,10 @@ namespace HttpMock.Integration.Tests
 
 		public static string GenerateAHostUrlForAStubServer()
 		{
-			return String.Format("http://localhost:{0}", PortHelper.FindLocalAvailablePortForTesting());
+		    lock (lckObject)
+		    {
+		        return String.Format("http://localhost:{0}", PortHelper.FindLocalAvailablePortForTesting());
+		    }
 		}
 	}
 }

--- a/src/HttpMock.Integration.Tests/HttpEndPointTests.cs
+++ b/src/HttpMock.Integration.Tests/HttpEndPointTests.cs
@@ -9,256 +9,254 @@ using System.Collections.Generic;
 
 namespace HttpMock.Integration.Tests
 {
-	[TestFixture]
-	public class HttpEndPointTests
-	{
-		private IHttpServer _stubHttp;
-		private string _hostUrl;
+    [TestFixture]
+    public class HttpEndPointTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            TestContext.CurrentContext.SetCurrentHostUrl(HostHelper.GenerateAHostUrlForAStubServer());
+        }
 
-		[SetUp]
-		public void SetUp()
-		{
-			_hostUrl = HostHelper.GenerateAHostUrlForAStubServer();
-		}
+        [Test]
+        public void SUT_should_return_stubbed_response()
+        {
+            
+            IHttpServer _stubHttp = HttpMockRepository.At(TestContext.CurrentContext.GetCurrentHostUrl());
 
-		[Test]
-		public void SUT_should_return_stubbed_response()
-		{
-			_stubHttp = HttpMockRepository.At(_hostUrl);
-
-			const string expected = "<xml><>response>Hello World</response></xml>";
-			_stubHttp.Stub(x => x.Get("/endpoint"))
-				.Return(expected)
-				.OK();
+            const string expected = "<xml><>response>Hello World</response></xml>";
+            _stubHttp.Stub(x => x.Get("/endpoint"))
+                .Return(expected)
+                .OK();
 
 
 
-			string result = new WebClient().DownloadString(string.Format("{0}/endpoint", _hostUrl));
+            string result = new WebClient().DownloadString(string.Format("{0}/endpoint", TestContext.CurrentContext.GetCurrentHostUrl()));
 
-			Assert.That(result, Is.EqualTo(expected));
-		}
+            Assert.That(result, Is.EqualTo(expected));
+        }
 
         [TestCase(1)]
         [TestCase(100)]
         [TestCase(5000)]
         public void SUT_should_get_back_exact_content_in_the_last_request_body(int count)
         {
-            _stubHttp = HttpMockRepository.At(_hostUrl);
+            IHttpServer _stubHttp = HttpMockRepository.At(TestContext.CurrentContext.GetCurrentHostUrl());
 
             string expected = string.Format("<xml><>response>{0}</response></xml>", string.Join(" ", Enumerable.Range(0, count)));
             var requestHandler = _stubHttp.Stub(x => x.Post("/endpoint"));
 
             requestHandler.Return(expected).OK();
 
-            
+
 
             using (var wc = new WebClient())
             {
                 wc.Headers[HttpRequestHeader.ContentType] = "application/xml";
-                wc.UploadString(string.Format("{0}/endpoint", _hostUrl), expected);
+                wc.UploadString(string.Format("{0}/endpoint", TestContext.CurrentContext.GetCurrentHostUrl()), expected);
             }
             var requestBody = ((RequestHandler)requestHandler).LastRequest().Body;
 
             Assert.That(requestBody, Is.EqualTo(expected));
-        }      
+        }
 
 
-		[Test]
-		public void Should_start_listening_before_stubs_have_been_set()
-		{
-			_stubHttp = HttpMockRepository.At(_hostUrl);
+        [Test]
+        public void Should_start_listening_before_stubs_have_been_set()
+        {
+            IHttpServer _stubHttp = HttpMockRepository.At(TestContext.CurrentContext.GetCurrentHostUrl());
 
-			_stubHttp.Stub(x => x.Get("/endpoint"))
-				.Return("listening")
-				.OK();
+            _stubHttp.Stub(x => x.Get("/endpoint"))
+                .Return("listening")
+                .OK();
 
-			using (var tcpClient = new TcpClient())
-			{
-				var uri = new Uri(_hostUrl);
+            using (var tcpClient = new TcpClient())
+            {
+                var uri = new Uri(TestContext.CurrentContext.GetCurrentHostUrl());
 
-				tcpClient.Connect(uri.Host, uri.Port);
+                tcpClient.Connect(uri.Host, uri.Port);
 
-				Assert.That(tcpClient.Connected, Is.True);
+                Assert.That(tcpClient.Connected, Is.True);
 
-				tcpClient.Close();
-			}
+                tcpClient.Close();
+            }
 
-			string result = new WebClient().DownloadString(string.Format("{0}/endpoint", _hostUrl));
+            string result = new WebClient().DownloadString(string.Format("{0}/endpoint", TestContext.CurrentContext.GetCurrentHostUrl()));
 
-			Assert.That(result, Is.EqualTo("listening"));
-		}
+            Assert.That(result, Is.EqualTo("listening"));
+        }
 
-		[Test]
-		public void Should_return_expected_ok_response()
-		{
-			_stubHttp = HttpMockRepository.At(_hostUrl);
+        [Test]
+        public void Should_return_expected_ok_response()
+        {
+            IHttpServer _stubHttp = HttpMockRepository.At(TestContext.CurrentContext.GetCurrentHostUrl());
 
-			_stubHttp
-				.Stub(x => x.Get("/api2/status"))
-				.Return("Hello")
-				.OK();
+            _stubHttp
+                .Stub(x => x.Get("/api2/status"))
+                .Return("Hello")
+                .OK();
 
-			_stubHttp
-				.Stub(x => x.Get("/api2/echo"))
-				.Return("Echo")
-				.NotFound();
+            _stubHttp
+                .Stub(x => x.Get("/api2/echo"))
+                .Return("Echo")
+                .NotFound();
 
-			_stubHttp
-				.Stub(x => x.Get("/api2/echo2"))
-				.Return("Nothing")
-				.WithStatus(HttpStatusCode.Unauthorized);
-
-
-
-			var wc = new WebClient();
-
-			Assert.That(wc.DownloadString(string.Format("{0}/api2/status", _hostUrl)), Is.EqualTo("Hello"));
-
-			try
-			{
-				Console.WriteLine(wc.DownloadString(_hostUrl + "/api2/echo"));
-			}
-			catch (Exception ex)
-			{
-				Assert.That(ex, Is.InstanceOf(typeof (WebException)));
-				Assert.That(((WebException) ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
-			}
-
-			try
-			{
-				wc.DownloadString(_hostUrl + "/api2/echo2");
-			}
-			catch (Exception ex)
-			{
-				Assert.That(ex, Is.InstanceOf(typeof (WebException)));
-				Assert.That(((WebException) ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
-			}
-		}
-
-
-		[Test]
-		public void Should_hit_the_same_url_multiple_times()
-		{
-			string endpoint = _hostUrl;
-			_stubHttp = HttpMockRepository.At(endpoint);
-
-
-			_stubHttp
-				.Stub(x => x.Get("/api2/echo"))
-				.Return("Echo")
-				.NotFound();
-
-			_stubHttp
-				.Stub(x => x.Get("/api2/echo2"))
-				.Return("Nothing")
-				.WithStatus(HttpStatusCode.Unauthorized);
+            _stubHttp
+                .Stub(x => x.Get("/api2/echo2"))
+                .Return("Nothing")
+                .WithStatus(HttpStatusCode.Unauthorized);
 
 
 
-			for (int count = 0; count < 6; count++)
-			{
-				RequestEcho(endpoint);
-			}
-		}
+            var wc = new WebClient();
 
-		[Test]
-		public void Should_support_range_requests()
-		{
-			_stubHttp = HttpMockRepository.At(_hostUrl);
-			string query = "/path/file";
-			int fileSize = 2048;
-			string pathToFile = CreateFile(fileSize);
+            Assert.That(wc.DownloadString(string.Format("{0}/api2/status", TestContext.CurrentContext.GetCurrentHostUrl())), Is.EqualTo("Hello"));
 
-			try
-			{
-				_stubHttp.Stub(x => x.Get(query))
-					.ReturnFileRange(pathToFile, 0, 1023)
-					.WithStatus(HttpStatusCode.PartialContent);
+            try
+            {
+                Console.WriteLine(wc.DownloadString(TestContext.CurrentContext.GetCurrentHostUrl() + "/api2/echo"));
+            }
+            catch (Exception ex)
+            {
+                Assert.That(ex, Is.InstanceOf(typeof(WebException)));
+                Assert.That(((WebException)ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
+            }
+
+            try
+            {
+                wc.DownloadString(TestContext.CurrentContext.GetCurrentHostUrl() + "/api2/echo2");
+            }
+            catch (Exception ex)
+            {
+                Assert.That(ex, Is.InstanceOf(typeof(WebException)));
+                Assert.That(((WebException)ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
+            }
+        }
 
 
+        [Test]
+        public void Should_hit_the_same_url_multiple_times()
+        {
+            string endpoint = TestContext.CurrentContext.GetCurrentHostUrl();
+            IHttpServer _stubHttp = HttpMockRepository.At(endpoint);
 
-				HttpWebRequest request = (HttpWebRequest) HttpWebRequest.Create(_hostUrl + query);
-				request.Method = "GET";
-				request.AddRange(0, 1023);
-				HttpWebResponse response = (HttpWebResponse) request.GetResponse();
-				byte[] downloadData = new byte[response.ContentLength];
-				using (response)
-				{
-					response.GetResponseStream().Read(downloadData, 0, downloadData.Length);
-				}
-				Assert.That(downloadData.Length, Is.EqualTo(1024));
-			}
-			finally
-			{
-				try
-				{
-					File.Delete(pathToFile);
-				}
-				catch
-				{
-				}
-			}
-		}
 
-		[Test]
-		public void SUT_should_return_stubbed_response_for_custom_verbs()
-		{
-			_stubHttp = HttpMockRepository.At(_hostUrl);
+            _stubHttp
+                .Stub(x => x.Get("/api2/echo"))
+                .Return("Echo")
+                .NotFound();
 
-			const string expected = "<xml><>response>Hello World</response></xml>";
-			_stubHttp.Stub(x => x.CustomVerb("/endpoint", "PURGE"))
-				.Return(expected)
-				.OK();
+            _stubHttp
+                .Stub(x => x.Get("/api2/echo2"))
+                .Return("Nothing")
+                .WithStatus(HttpStatusCode.Unauthorized);
 
 
 
-			var request = (HttpWebRequest) WebRequest.Create(string.Format("{0}/endpoint", _hostUrl));
-			request.Method = "PURGE";
-			request.Host = "nonstandard.host";
-			request.Headers.Add("X-Go-Faster", "11");
-			using (var response = request.GetResponse())
-			using (var stream = response.GetResponseStream())
-			{
-				var responseBody = new StreamReader(stream).ReadToEnd();
-				Assert.That(responseBody, Is.EqualTo(expected));
-			}
-		}
+            for (int count = 0; count < 6; count++)
+            {
+                RequestEcho(endpoint);
+            }
+        }
 
-		private string CreateFile(int fileSize)
-		{
-			string fileName = Path.GetTempFileName();
-			using (FileStream fileStream = File.OpenWrite(fileName))
-			{
-				for (int count = 0; count < fileSize; count++)
-				{
-					fileStream.WriteByte((byte) count);
-				}
-				fileStream.Close();
-			}
-			return fileName;
-		}
+        [Test]
+        public void Should_support_range_requests()
+        {
+            IHttpServer _stubHttp = HttpMockRepository.At(TestContext.CurrentContext.GetCurrentHostUrl());
+            string query = "/path/file";
+            int fileSize = 2048;
+            string pathToFile = CreateFile(fileSize);
 
-		private static void RequestEcho(string endpoint)
-		{
-			var wc = new WebClient();
+            try
+            {
+                _stubHttp.Stub(x => x.Get(query))
+                    .ReturnFileRange(pathToFile, 0, 1023)
+                    .WithStatus(HttpStatusCode.PartialContent);
 
-			try
-			{
-				wc.DownloadString(endpoint + "/api2/echo");
-			}
-			catch (Exception ex)
-			{
-				Assert.That(ex, Is.InstanceOf(typeof (WebException)));
-				Assert.That(((WebException) ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
-			}
-		}
-		
-		[TestCase(1)]
+
+
+                HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create(TestContext.CurrentContext.GetCurrentHostUrl() + query);
+                request.Method = "GET";
+                request.AddRange(0, 1023);
+                HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+                byte[] downloadData = new byte[response.ContentLength];
+                using (response)
+                {
+                    response.GetResponseStream().Read(downloadData, 0, downloadData.Length);
+                }
+                Assert.That(downloadData.Length, Is.EqualTo(1024));
+            }
+            finally
+            {
+                try
+                {
+                    File.Delete(pathToFile);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        [Test]
+        public void SUT_should_return_stubbed_response_for_custom_verbs()
+        {
+            IHttpServer _stubHttp = HttpMockRepository.At(TestContext.CurrentContext.GetCurrentHostUrl());
+
+            const string expected = "<xml><>response>Hello World</response></xml>";
+            _stubHttp.Stub(x => x.CustomVerb("/endpoint", "PURGE"))
+                .Return(expected)
+                .OK();
+
+
+
+            var request = (HttpWebRequest)WebRequest.Create(string.Format("{0}/endpoint", TestContext.CurrentContext.GetCurrentHostUrl()));
+            request.Method = "PURGE";
+            request.Host = "nonstandard.host";
+            request.Headers.Add("X-Go-Faster", "11");
+            using (var response = request.GetResponse())
+            using (var stream = response.GetResponseStream())
+            {
+                var responseBody = new StreamReader(stream).ReadToEnd();
+                Assert.That(responseBody, Is.EqualTo(expected));
+            }
+        }
+
+        private string CreateFile(int fileSize)
+        {
+            string fileName = Path.GetTempFileName();
+            using (FileStream fileStream = File.OpenWrite(fileName))
+            {
+                for (int count = 0; count < fileSize; count++)
+                {
+                    fileStream.WriteByte((byte)count);
+                }
+                fileStream.Close();
+            }
+            return fileName;
+        }
+
+        private static void RequestEcho(string endpoint)
+        {
+            var wc = new WebClient();
+
+            try
+            {
+                wc.DownloadString(endpoint + "/api2/echo");
+            }
+            catch (Exception ex)
+            {
+                Assert.That(ex, Is.InstanceOf(typeof(WebException)));
+                Assert.That(((WebException)ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
+            }
+        }
+
+        [TestCase(1)]
         [TestCase(10)]
         [TestCase(50)]
         public void SUT_should_get_back_the_collection_of_requests(int count)
         {
-            _stubHttp = HttpMockRepository.At(_hostUrl);
+            IHttpServer _stubHttp = HttpMockRepository.At(TestContext.CurrentContext.GetCurrentHostUrl());
 
             var requestHandlerStub = _stubHttp.Stub(x => x.Post("/endpoint"));
 
@@ -271,7 +269,7 @@ namespace HttpMock.Integration.Tests
                 for (int i = 0; i < count; i++)
                 {
                     string expected = string.Format("<xml><>response>{0}</response></xml>", string.Join(" ", Enumerable.Range(0, i)));
-                    wc.UploadString(string.Format("{0}/endpoint", _hostUrl), expected);
+                    wc.UploadString(string.Format("{0}/endpoint", TestContext.CurrentContext.GetCurrentHostUrl()), expected);
                     expectedBodyList.Add(expected);
                 }
             }
@@ -286,5 +284,5 @@ namespace HttpMock.Integration.Tests
                 Assert.AreEqual(expectedBodyList.ElementAt(i), observedRequests.ElementAt(i).Body);
             }
         }
-	}
+    }
 }

--- a/src/HttpMock.Integration.Tests/HttpMock.Integration.Tests.csproj
+++ b/src/HttpMock.Integration.Tests/HttpMock.Integration.Tests.csproj
@@ -40,8 +40,9 @@
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a">
       <HintPath>..\..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb">
-      <HintPath>..\..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/HttpMock.Integration.Tests/HttpMock.Integration.Tests.csproj
+++ b/src/HttpMock.Integration.Tests/HttpMock.Integration.Tests.csproj
@@ -58,6 +58,8 @@
     <Compile Include="HttpEndPointTests.cs" />
     <Compile Include="HttpExpectationTests.cs" />
     <Compile Include="HttpFactoryTests.cs" />
+    <Compile Include="MultipleTestsUsingTheSameStubServerAndParallelScenariosWithCookieAsHeader.cs" />
+    <Compile Include="MultipleTestsUsingTheSameStubServerAndParallelScenarios.cs" />
     <Compile Include="MultipleTestsUsingTheSameStubServerAndDifferentUris.cs" />
     <Compile Include="MultipleTestsUsingTheSameStubServerWithDifferentHttpMethods.cs" />
     <Compile Include="PortHelper.cs" />

--- a/src/HttpMock.Integration.Tests/HttpMock.Integration.Tests.csproj
+++ b/src/HttpMock.Integration.Tests/HttpMock.Integration.Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="SameServerUsingDifferentBaseUrlsTests.cs" />
     <Compile Include="StubConstraintsTests.cs" />
     <Compile Include="SystemUnderTest.cs" />
+    <Compile Include="TestContextExtension.cs" />
     <Compile Include="UsingMultipleServersTests.cs" />
     <Compile Include="UsingTheSameStubServerAndDifferentQueryRequestParams.cs" />
     <Compile Include="UsingTheSameStubServerAndDifferentRequestHeaders.cs" />
@@ -101,6 +102,9 @@
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/HttpMock.Integration.Tests/MultipleTestsUsingTheSameStubServerAndDifferentUris.cs
+++ b/src/HttpMock.Integration.Tests/MultipleTestsUsingTheSameStubServerAndDifferentUris.cs
@@ -6,30 +6,28 @@ namespace HttpMock.Integration.Tests
 	[TestFixture]
 	public class MultipleTestsUsingTheSameStubServerAndDifferentUris
 	{
-		private IHttpServer _httpMockRepository;
-		private string _hostUrl;
-
 		[SetUp]
 		public void SetUp()
 		{
-			_hostUrl = HostHelper.GenerateAHostUrlForAStubServer();
-			_httpMockRepository = HttpMockRepository.At(_hostUrl);
-		}
+		    var hostUrl = HostHelper.GenerateAHostUrlForAStubServer();
+		    TestContext.CurrentContext.SetCurrentHostUrl(hostUrl);
+		    TestContext.CurrentContext.SetCurrentHttpMock(HttpMockRepository.At(hostUrl));
+        }
 
 		[Test]
 		public void FirstTest()
 		{
 			var wc = new WebClient();
 			string stubbedReponse = "Response for first test";
-			var stubHttp = _httpMockRepository
-				.WithNewContext();
+			var stubHttp = TestContext.CurrentContext.GetCurrentHttpMock()
+                .WithNewContext();
 
 			stubHttp
 				.Stub(x => x.Post("/firsttest"))
 				.Return(stubbedReponse)
 				.OK();
 
-			Assert.That(wc.UploadString(string.Format("{0}/firsttest/", _hostUrl), "x"), Is.EqualTo(stubbedReponse));
+			Assert.That(wc.UploadString(string.Format("{0}/firsttest/", TestContext.CurrentContext.GetCurrentHostUrl()), "x"), Is.EqualTo(stubbedReponse));
 		}
 
 		[Test]
@@ -37,13 +35,13 @@ namespace HttpMock.Integration.Tests
 		{
 			var wc = new WebClient();
 			string stubbedReponse = "Response for second test";
-			_httpMockRepository
-				.WithNewContext()
+		    TestContext.CurrentContext.GetCurrentHttpMock()
+                .WithNewContext()
 				.Stub(x => x.Post("/secondtest"))
 				.Return(stubbedReponse)
 				.OK();
 
-			Assert.That(wc.UploadString(string.Format("{0}/secondtest/", _hostUrl), "x"), Is.EqualTo(stubbedReponse));
+			Assert.That(wc.UploadString(string.Format("{0}/secondtest/", TestContext.CurrentContext.GetCurrentHostUrl()), "x"), Is.EqualTo(stubbedReponse));
 		}
 
 		[Test]
@@ -53,7 +51,7 @@ namespace HttpMock.Integration.Tests
 			string stubbedReponseOne = "Response for first test in context";
 			string stubbedReponseTwo = "Response for second test in context";
 
-			IHttpServer stubHttp = _httpMockRepository.WithNewContext();
+			IHttpServer stubHttp = TestContext.CurrentContext.GetCurrentHttpMock().WithNewContext();
 
 			stubHttp.Stub(x => x.Post("/firsttest"))
 				.Return(stubbedReponseOne)
@@ -63,8 +61,8 @@ namespace HttpMock.Integration.Tests
 				.Return(stubbedReponseTwo)
 				.OK();
 
-			Assert.That(wc.UploadString(string.Format("{0}/firsttest/", _hostUrl), "x"), Is.EqualTo(stubbedReponseOne));
-			Assert.That(wc.UploadString(string.Format("{0}/secondtest/", _hostUrl), "x"), Is.EqualTo(stubbedReponseTwo));
+			Assert.That(wc.UploadString(string.Format("{0}/firsttest/", TestContext.CurrentContext.GetCurrentHostUrl()), "x"), Is.EqualTo(stubbedReponseOne));
+			Assert.That(wc.UploadString(string.Format("{0}/secondtest/", TestContext.CurrentContext.GetCurrentHostUrl()), "x"), Is.EqualTo(stubbedReponseTwo));
 		}
 	}
 }

--- a/src/HttpMock.Integration.Tests/MultipleTestsUsingTheSameStubServerAndParallelScenarios.cs
+++ b/src/HttpMock.Integration.Tests/MultipleTestsUsingTheSameStubServerAndParallelScenarios.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using NUnit.Framework;
+
+namespace HttpMock.Integration.Tests
+{
+    [TestFixture]
+    public class MultipleTestsUsingTheSameStubServerAndParallelScenarios
+    {
+        private string hostUrl;
+        private IHttpServer stubHttp;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            hostUrl = HostHelper.GenerateAHostUrlForAStubServer();
+            stubHttp = HttpMockRepository.At(hostUrl);
+        }
+
+        [Test, Repeat(50)]
+        public void FirstTestWithSession()
+        {
+            var wc = new WebClient();
+            string sessionId = Guid.NewGuid().ToString();
+            string stubbedReponse = $"Response for first test with {sessionId}";
+
+            stubHttp
+                .Stub(x => x.Post("/firsttest"))
+                .WithHeaders(new Dictionary<string, string>() { { Constants.MockSessionHeaderKey, sessionId } })
+                .Return(stubbedReponse)
+                .OK();
+            wc.Headers.Add(Constants.MockSessionHeaderKey, sessionId);
+            Assert.That(wc.UploadString(string.Format("{0}/firsttest/", hostUrl), "x"), Is.EqualTo(stubbedReponse));
+        }
+
+        [Test, Repeat(50)]
+        public void SecondTestWithSession()
+        {
+            var wc = new WebClient();
+            string sessionId = Guid.NewGuid().ToString();
+            string stubbedReponse = $"Response for second test with {sessionId}";
+            stubHttp
+                .Stub(x => x.Post("/secondtest"))
+                .WithHeaders(new Dictionary<string, string>() { { Constants.MockSessionHeaderKey, sessionId } })
+                .Return(stubbedReponse)
+                .OK();
+
+            wc.Headers.Add(Constants.MockSessionHeaderKey, sessionId);
+            Assert.That(wc.UploadString(string.Format("{0}/secondtest/", hostUrl), "x"), Is.EqualTo(stubbedReponse));
+        }
+
+        [Test, Repeat(50)]
+        public void Stubs_should_be_unique_within_contextWithSession()
+        {
+            var wc = new WebClient();
+            string sessionId = Guid.NewGuid().ToString();
+            string stubbedReponseOne = $"Response for first test in context with {sessionId}";
+            string stubbedReponseTwo = $"Response for second test in context with {sessionId}";
+
+            stubHttp.Stub(x => x.Post("/firsttest"))
+                .WithHeaders(new Dictionary<string, string>() { { Constants.MockSessionHeaderKey, sessionId } })
+                .Return(stubbedReponseOne)
+                .OK();
+
+            stubHttp.Stub(x => x.Post("/secondtest"))
+                .WithHeaders(new Dictionary<string, string>() { { Constants.MockSessionHeaderKey, sessionId } })
+                .Return(stubbedReponseTwo)
+                .OK();
+
+            wc.Headers.Add(Constants.MockSessionHeaderKey, sessionId);
+            Assert.That(wc.UploadString(string.Format("{0}/firsttest/", hostUrl), "x"), Is.EqualTo(stubbedReponseOne));
+            Assert.That(wc.UploadString(string.Format("{0}/secondtest/", hostUrl), "x"), Is.EqualTo(stubbedReponseTwo));
+        }
+
+        [Test, Repeat(50)]
+        public void Stubs_should_Clear_PrevStub_WithNewContext_AndContextWithSession()
+        {
+            var wc = new WebClient();
+            Guid sessionId = Guid.NewGuid();
+            string stubbedReponse = $"Response for first test in context with {sessionId}";
+
+            stubHttp.Stub(x => x.Post("/firsttest"))
+                .WithHeaders(new Dictionary<string, string>() { { Constants.MockSessionHeaderKey, sessionId.ToString() } })
+                .Return(stubbedReponse)
+                .OK();
+            wc.Headers.Add(Constants.MockSessionHeaderKey, sessionId.ToString());
+            Assert.That(wc.UploadString(string.Format("{0}/firsttest/", hostUrl), "x"), Is.EqualTo(stubbedReponse));
+
+            wc = new WebClient();
+            stubHttp.WithNewContext(sessionId);
+            stubbedReponse = $"Response for edited first test in context with {sessionId}";
+            stubHttp.Stub(x => x.Post("/firsttest"))
+                .WithHeaders(new Dictionary<string, string>() { { Constants.MockSessionHeaderKey, sessionId.ToString() } })
+                .Return(stubbedReponse)
+                .OK();
+
+            wc.Headers.Add(Constants.MockSessionHeaderKey, sessionId.ToString());
+            Assert.That(wc.UploadString(string.Format("{0}/firsttest/", hostUrl), "x"), Is.EqualTo(stubbedReponse));
+        }
+
+
+
+    }
+}

--- a/src/HttpMock.Integration.Tests/MultipleTestsUsingTheSameStubServerAndParallelScenariosWithCookieAsHeader.cs
+++ b/src/HttpMock.Integration.Tests/MultipleTestsUsingTheSameStubServerAndParallelScenariosWithCookieAsHeader.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using NUnit.Framework;
+
+namespace HttpMock.Integration.Tests
+{
+    [TestFixture]
+    public class MultipleTestsUsingTheSameStubServerAndParallelScenariosWithCookieAsHeader
+    {
+        private string hostUrl;
+        private IHttpServer stubHttp;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            hostUrl = HostHelper.GenerateAHostUrlForAStubServer();
+            stubHttp = HttpMockRepository.At(hostUrl);
+        }
+
+        [Test, Repeat(50)]
+        public void FirstTestWithSession()
+        {
+            var wc = new WebClient();
+            string sessionId = Guid.NewGuid().ToString();
+            string stubbedReponse = $"Response for first test with {sessionId}";
+
+            stubHttp
+                .Stub(x => x.Post("/firsttest"))
+                .WithHeaders(new Dictionary<string, string>() { { $"{Constants.CookieHeaderKey}", $"{Constants.MockSessionHeaderKey}={sessionId}" } })
+                .Return(stubbedReponse)
+                .OK();
+            wc.Headers.Add(Constants.CookieHeaderKey, $"{Constants.MockSessionHeaderKey}={sessionId}");
+            Assert.That(wc.UploadString(string.Format("{0}/firsttest/", hostUrl), "x"), Is.EqualTo(stubbedReponse));
+        }
+
+        [Test, Repeat(50)]
+        public void SecondTestWithSession()
+        {
+            var wc = new WebClient();
+            string sessionId = Guid.NewGuid().ToString();
+            string stubbedReponse = $"Response for second test with {sessionId}";
+            stubHttp
+                .Stub(x => x.Post("/secondtest"))
+                .WithHeaders(new Dictionary<string, string>() { { $"{Constants.CookieHeaderKey}", $"{Constants.MockSessionHeaderKey}={sessionId}" } })
+                .Return(stubbedReponse)
+                .OK();
+
+            wc.Headers.Add(Constants.CookieHeaderKey, $"{Constants.MockSessionHeaderKey}={sessionId}");
+            Assert.That(wc.UploadString(string.Format("{0}/secondtest/", hostUrl), "x"), Is.EqualTo(stubbedReponse));
+        }
+
+        [Test, Repeat(50)]
+        public void Stubs_should_be_unique_within_contextWithSession()
+        {
+            var wc = new WebClient();
+            string sessionId = Guid.NewGuid().ToString();
+            string stubbedReponseOne = $"Response for first test in context with {sessionId}";
+            string stubbedReponseTwo = $"Response for second test in context with {sessionId}";
+
+            stubHttp.Stub(x => x.Post("/firsttest"))
+                .WithHeaders(new Dictionary<string, string>() { { $"{Constants.CookieHeaderKey}", $"{Constants.MockSessionHeaderKey}={sessionId}" } })
+                .Return(stubbedReponseOne)
+                .OK();
+
+            stubHttp.Stub(x => x.Post("/secondtest"))
+                .WithHeaders(new Dictionary<string, string>() { { $"{Constants.CookieHeaderKey}", $"{Constants.MockSessionHeaderKey}={sessionId}" } })
+                .Return(stubbedReponseTwo)
+                .OK();
+
+            wc.Headers.Add(Constants.CookieHeaderKey, $"{Constants.MockSessionHeaderKey}={sessionId}");
+            Assert.That(wc.UploadString(string.Format("{0}/firsttest/", hostUrl), "x"), Is.EqualTo(stubbedReponseOne));
+            Assert.That(wc.UploadString(string.Format("{0}/secondtest/", hostUrl), "x"), Is.EqualTo(stubbedReponseTwo));
+        }
+
+        [Test, Repeat(50)]
+        public void Stubs_should_Clear_PrevStub_WithNewContext_AndContextWithSession()
+        {
+            var wc = new WebClient();
+            Guid sessionId = Guid.NewGuid();
+            string stubbedReponse = $"Response for first test in context with {sessionId}";
+
+            stubHttp.Stub(x => x.Post("/firsttest"))
+                .WithHeaders(new Dictionary<string, string>() { { Constants.MockSessionHeaderKey, sessionId.ToString() } })
+                .Return(stubbedReponse)
+                .OK();
+            wc.Headers.Add(Constants.MockSessionHeaderKey, sessionId.ToString());
+            Assert.That(wc.UploadString(string.Format("{0}/firsttest/", hostUrl), "x"), Is.EqualTo(stubbedReponse));
+
+            wc = new WebClient();
+            stubHttp.WithNewContext(sessionId);
+            stubbedReponse = $"Response for edited first test in context with {sessionId}";
+            stubHttp.Stub(x => x.Post("/firsttest"))
+                .WithHeaders(new Dictionary<string, string>() { { Constants.MockSessionHeaderKey, sessionId.ToString() } })
+                .Return(stubbedReponse)
+                .OK();
+
+            wc.Headers.Add(Constants.MockSessionHeaderKey, sessionId.ToString());
+            Assert.That(wc.UploadString(string.Format("{0}/firsttest/", hostUrl), "x"), Is.EqualTo(stubbedReponse));
+        }
+
+        [Test, Repeat(50)]
+        public void FirstTestWithSessionWithWrongCookieHeaderShouldThrowException()
+        {
+            var wc = new WebClient();
+            string sessionId = Guid.NewGuid().ToString();
+            string stubbedReponse = $"Response for first test with {sessionId}";
+
+            stubHttp
+                .Stub(x => x.Post("/firsttest"))
+                .WithHeaders(new Dictionary<string, string>() { { $"{Constants.CookieHeaderKey}", $"{Constants.MockSessionHeaderKey}={sessionId}" } })
+                .Return(stubbedReponse)
+                .OK();
+            wc.Headers.Add(Constants.CookieHeaderKey, $"{Constants.MockSessionHeaderKey}:{sessionId}");
+            Assert.Throws<WebException>(() => wc.UploadString(string.Format("{0}/firsttest/", hostUrl), "x"), "The remote server returned an error: (404) Not Found.");
+        }
+
+        [Test, Repeat(50)]
+        public void SecondTestWithSessionWithWrongCookieHeaderShouldThrowException()
+        {
+            var wc = new WebClient();
+            string sessionId = Guid.NewGuid().ToString();
+            string stubbedReponse = $"Response for second test with {sessionId}";
+            stubHttp
+                .Stub(x => x.Post("/secondtest"))
+                .WithHeaders(new Dictionary<string, string>() { { $"{Constants.CookieHeaderKey}", $"{Constants.MockSessionHeaderKey}={sessionId}" } })
+                .Return(stubbedReponse)
+                .OK();
+
+            wc.Headers.Add(Constants.CookieHeaderKey, $"{Constants.MockSessionHeaderKey}:{sessionId}");
+            Assert.Throws<WebException>(() => wc.UploadString(string.Format("{0}/secondtest/", hostUrl), "x"), "The remote server returned an error: (404) Not Found.");
+        }
+
+        [Test, Repeat(50)]
+        public void Stubs_should_be_unique_within_contextWithSessionWithWrongCookieHeaderShouldThrowException()
+        {
+            var wc = new WebClient();
+            string sessionId = Guid.NewGuid().ToString();
+            string stubbedReponseOne = $"Response for first test in context with {sessionId}";
+            string stubbedReponseTwo = $"Response for second test in context with {sessionId}";
+
+            stubHttp.Stub(x => x.Post("/firsttest"))
+                .WithHeaders(new Dictionary<string, string>() { { $"{Constants.CookieHeaderKey}", $"{Constants.MockSessionHeaderKey}={sessionId}" } })
+                .Return(stubbedReponseOne)
+                .OK();
+
+            stubHttp.Stub(x => x.Post("/secondtest"))
+                .WithHeaders(new Dictionary<string, string>() { { $"{Constants.CookieHeaderKey}", $"{Constants.MockSessionHeaderKey}={sessionId}" } })
+                .Return(stubbedReponseTwo)
+                .OK();
+
+            wc.Headers.Add(Constants.CookieHeaderKey, $"{Constants.MockSessionHeaderKey}:{sessionId}");
+            Assert.Throws<WebException>(() => wc.UploadString(string.Format("{0}/firsttest/", hostUrl), "x"), "The remote server returned an error: (404) Not Found.");
+            Assert.Throws<WebException>(() => wc.UploadString(string.Format("{0}/secondtest/", hostUrl), "x"), "The remote server returned an error: (404) Not Found.");
+        }
+
+        [Test, Repeat(50)]
+        public void Stubs_should_Clear_PrevStub_WithNewContext_AndContextWithSessionWithWrongCookieHeaderShouldThrowException()
+        {
+            var wc = new WebClient();
+            Guid sessionId = Guid.NewGuid();
+            string stubbedReponse = $"Response for first test in context with {sessionId}";
+
+            stubHttp.Stub(x => x.Post("/firsttest"))
+                .WithHeaders(new Dictionary<string, string>() { { Constants.MockSessionHeaderKey, sessionId.ToString() } })
+                .Return(stubbedReponse)
+                .OK();
+            wc.Headers.Add(Constants.CookieHeaderKey, $"{Constants.MockSessionHeaderKey}:{sessionId}");
+            Assert.Throws<WebException>(() => wc.UploadString(string.Format("{0}/firsttest/", hostUrl), "x"), "The remote server returned an error: (404) Not Found.");
+
+            wc = new WebClient();
+            stubHttp.WithNewContext(sessionId);
+            stubbedReponse = $"Response for edited first test in context with {sessionId}";
+            stubHttp.Stub(x => x.Post("/firsttest"))
+                .WithHeaders(new Dictionary<string, string>() { { Constants.MockSessionHeaderKey, sessionId.ToString() } })
+                .Return(stubbedReponse)
+                .OK();
+
+            wc.Headers.Add(Constants.CookieHeaderKey, $"{Constants.MockSessionHeaderKey}:{sessionId}");
+            Assert.Throws<WebException>(() => wc.UploadString(string.Format("{0}/firsttest/", hostUrl), "x"), "The remote server returned an error: (404) Not Found.");
+        }
+
+
+
+    }
+}

--- a/src/HttpMock.Integration.Tests/MultipleTestsUsingTheSameStubServerWithDifferentHttpMethods.cs
+++ b/src/HttpMock.Integration.Tests/MultipleTestsUsingTheSameStubServerWithDifferentHttpMethods.cs
@@ -4,129 +4,139 @@ using NUnit.Framework;
 
 namespace HttpMock.Integration.Tests
 {
-	[TestFixture]
-	public class MultipleTestsUsingTheSameStubServerWithDifferentHttpMethods
-	{
-		private string _endpointToHit;
-		private IHttpServer _httpMockRepository;
+    [TestFixture]
+    public class MultipleTestsUsingTheSameStubServerWithDifferentHttpMethods
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            var url = HostHelper.GenerateAHostUrlForAStubServerWith("endpoint");
+            TestContext.CurrentContext.SetCurrentHostUrl(url);
+            TestContext.CurrentContext.SetCurrentHttpMock(HttpMockRepository.At(url));
+        }
 
-		[SetUp]
-		public void SetUp()
-		{
-			_endpointToHit = HostHelper.GenerateAHostUrlForAStubServerWith("endpoint");
-			_httpMockRepository = HttpMockRepository.At(_endpointToHit);
-		}
+        [Test]
+        public void Should_get()
+        {
+            var httpMockRepository = TestContext.CurrentContext.GetCurrentHttpMock();
+            httpMockRepository
+                .Stub(x => x.Get("/endpoint"))
+                .Return("I am a GET")
+                .OK();
 
-		[Test]
-		public void Should_get()
-		{
-			_httpMockRepository
-				.Stub(x => x.Get("/endpoint"))
-				.Return("I am a GET")
-				.OK();
+            AssertResponse("GET", "I am a GET");
+        }
 
-			AssertResponse("GET", "I am a GET");
-		}
+        [Test]
+        public void Should_post()
+        {
+            var httpMockRepository = TestContext.CurrentContext.GetCurrentHttpMock();
+            httpMockRepository
+                .Stub(x => x.Post("/endpoint"))
+                .Return("I am a POST")
+                .OK();
 
-		[Test]
-		public void Should_post()
-		{
-			_httpMockRepository
-				.Stub(x => x.Post("/endpoint"))
-				.Return("I am a POST")
-				.OK();
+            AssertResponse("POST", "I am a POST");
+        }
 
-			AssertResponse("POST", "I am a POST");
-		}
+        [Test]
+        public void Should_put()
+        {
+            var httpMockRepository = TestContext.CurrentContext.GetCurrentHttpMock();
+            httpMockRepository
+                .Stub(x => x.Put("/endpoint"))
+                .Return("I am a PUT")
+                .OK();
 
-		[Test]
-		public void Should_put()
-		{
-			_httpMockRepository
-				.Stub(x => x.Put("/endpoint"))
-				.Return("I am a PUT")
-				.OK();
+            AssertResponse("PUT", "I am a PUT");
+        }
 
-			AssertResponse("PUT", "I am a PUT");
-		}
+        [Test]
+        public void Should_delete()
+        {
+            var httpMockRepository = TestContext.CurrentContext.GetCurrentHttpMock();
+            httpMockRepository
+                .Stub(x => x.Delete("/endpoint"))
+                .Return("I am a DELETE")
+                .OK();
 
-		[Test]
-		public void Should_delete()
-		{
-			_httpMockRepository
-				.Stub(x => x.Delete("/endpoint"))
-				.Return("I am a DELETE")
-				.OK();
+            AssertResponse("DELETE", "I am a DELETE");
+        }
 
-			AssertResponse("DELETE", "I am a DELETE");
-		}
+        [Test]
+        public void Should_use_custom_verbs()
+        {
+            var httpMockRepository = TestContext.CurrentContext.GetCurrentHttpMock();
+            httpMockRepository.Stub(x => x.CustomVerb("/endpoint", "PURGE")).Return("I am a PURGE").OK();
+            AssertResponse("PURGE", "I am a PURGE");
+        }
 
-		[Test]
-		public void Should_use_custom_verbs()
-		{
-			_httpMockRepository.Stub(x => x.CustomVerb("/endpoint", "PURGE")).Return("I am a PURGE").OK();
-			AssertResponse("PURGE", "I am a PURGE");
-		}
+        [Test]
+        public void Should_head()
+        {
+            var httpMockRepository = TestContext.CurrentContext.GetCurrentHttpMock();
+            httpMockRepository
+                .Stub(x => x.Head("/endpoint"))
+                .Return("I am a HEAD")
+                .OK();
 
-		[Test]
-		public void Should_head()
-		{
-			_httpMockRepository
-				.Stub(x => x.Head("/endpoint"))
-				.Return("I am a HEAD")
-				.OK();
+            var _endpointToHit = TestContext.CurrentContext.GetCurrentHostUrl();
+            var webRequest = (HttpWebRequest)WebRequest.Create(_endpointToHit);
+            webRequest.Method = "HEAD";
+            using (var response = webRequest.GetResponse())
+            {
+                Assert.That(response.Headers.Count, Is.GreaterThan(0));
 
-			var webRequest = (HttpWebRequest) WebRequest.Create(_endpointToHit);
-			webRequest.Method = "HEAD";
-			using (var response = webRequest.GetResponse())
-			{
-				Assert.That(response.Headers.Count, Is.GreaterThan(0));
+            }
+        }
 
-			}
-		}
+        [Test]
+        public void If_no_Mocked_Endpoints_matched_then_should_return_404_with_HttpMockError_status()
+        {
+            var httpMockRepository = TestContext.CurrentContext.GetCurrentHttpMock();
+            var _endpointToHit = TestContext.CurrentContext.GetCurrentHostUrl();
+            var webRequest = (HttpWebRequest)WebRequest.Create(_endpointToHit + "wibbles");
+            try
+            {
+                using (webRequest.GetResponse())
+                {
+                }
+            }
+            catch (WebException ex)
+            {
+                Assert.That(((HttpWebResponse)ex.Response).StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+                Assert.That(((HttpWebResponse)ex.Response).Headers["X-HttpMockError"], Is.Not.Null, "Header not set");
+            }
+        }
 
-		[Test]
-		public void If_no_Mocked_Endpoints_matched_then_should_return_404_with_HttpMockError_status()
-		{
-			var webRequest = (HttpWebRequest) WebRequest.Create(_endpointToHit + "wibbles");
-			try
-			{
-				using (webRequest.GetResponse())
-				{
-				}
-			}
-			catch (WebException ex)
-			{
-				Assert.That(((HttpWebResponse) ex.Response).StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
-				Assert.That(((HttpWebResponse) ex.Response).Headers["X-HttpMockError"], Is.Not.Null, "Header not set");
-			}
-		}
+        [Test]
+        public void Should_return_dynamic_data()
+        {
+            var httpMockRepository = TestContext.CurrentContext.GetCurrentHttpMock();
+            string value = "test1";
+            httpMockRepository
+                .Stub(x => x.Get("/endpoint"))
+                .Return(() => value)
+                .OK();
+            AssertResponse("GET", "test1");
+            value = "test2";
+            AssertResponse("GET", "test2");
+        }
 
-		[Test]
-		public void Should_return_dynamic_data()
-		{
-			string value = "test1";
-			_httpMockRepository
-				.Stub(x => x.Get("/endpoint"))
-				.Return(() => value)
-				.OK();
-			AssertResponse("GET", "test1");
-			value = "test2";
-			AssertResponse("GET", "test2");
-		}
+        private void AssertResponse(string method, string expected)
+        {
+            var _endpointToHit = TestContext.CurrentContext.GetCurrentHostUrl();
 
-		private void AssertResponse(string method, string expected)
-		{
-			var webRequest = (HttpWebRequest) WebRequest.Create(_endpointToHit);
-			webRequest.Method = method;
-			using (var response = webRequest.GetResponse())
-			{
-				using (var sr = new StreamReader(response.GetResponseStream()))
-				{
-					string readToEnd = sr.ReadToEnd();
-					Assert.That(readToEnd, Is.EqualTo(expected));
-				}
-			}
-		}
-	}
+            var webRequest = (HttpWebRequest)WebRequest.Create(_endpointToHit);
+            webRequest.Method = method;
+            using (var response = webRequest.GetResponse())
+            {
+                using (var sr = new StreamReader(response.GetResponseStream()))
+                {
+                    string readToEnd = sr.ReadToEnd();
+                    Assert.That(readToEnd, Is.EqualTo(expected));
+                }
+            }
+        }
+    }
 }

--- a/src/HttpMock.Integration.Tests/PortHelper.cs
+++ b/src/HttpMock.Integration.Tests/PortHelper.cs
@@ -9,11 +9,12 @@ namespace HttpMock.Integration.Tests
 {
 	internal static class PortHelper
 	{
-		internal static int FindLocalAvailablePortForTesting ()
+	    private static Random random = new Random();
+
+        internal static int FindLocalAvailablePortForTesting ()
 		{
 			const int minPort = 1024;
 
-			var random = new Random ();
 			var maxPort = 64000;
 			var randomPort = random.Next (minPort, maxPort);
 

--- a/src/HttpMock.Integration.Tests/Properties/AssemblyInfo.cs
+++ b/src/HttpMock.Integration.Tests/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using NUnit.Framework;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -34,3 +35,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: Parallelizable(ParallelScope.Children)]
+[assembly: LevelOfParallelism(50)]

--- a/src/HttpMock.Integration.Tests/SameServerUsingDifferentBaseUrlsTests.cs
+++ b/src/HttpMock.Integration.Tests/SameServerUsingDifferentBaseUrlsTests.cs
@@ -7,11 +7,14 @@ namespace HttpMock.Integration.Tests
 	public class SameServerUsingDifferentBaseUrlsTests
 	{
 		private string _hostUrl;
+	    private IHttpServer stubHttp;
 
-		[OneTimeSetUp]
+        [OneTimeSetUp]
 		public void SetUp()
 		{
 			_hostUrl = HostHelper.GenerateAHostUrlForAStubServer();
+		    stubHttp = HttpMockRepository.At(_hostUrl);
+		    stubHttp.IsAvailable();
 		}
 
 		[Test]
@@ -19,8 +22,8 @@ namespace HttpMock.Integration.Tests
 		{
 			string expected = "expected response";
 			var url = _hostUrl + "/appone";
-			HttpMockRepository.At(url)
-				.Stub(x => x.Get("/appone/endpoint"))
+		    stubHttp
+                .Stub(x => x.Get("/appone/endpoint"))
 				.Return(expected)
 				.OK();
 
@@ -35,7 +38,7 @@ namespace HttpMock.Integration.Tests
 			string expected = "expected response";
 
 			var url = _hostUrl + "/apptwo";
-			HttpMockRepository.At(url)
+			stubHttp
 				.Stub(x => x.Get("/apptwo/endpoint"))
 				.Return(expected)
 				.OK();
@@ -49,8 +52,8 @@ namespace HttpMock.Integration.Tests
 		{
 			string expected = "expected response";
 			var url = _hostUrl + "/appthree";
-			HttpMockRepository.At(url)
-				.Stub(x => x.Get("/appthree/endpoint"))
+		    stubHttp
+                .Stub(x => x.Get("/appthree/endpoint"))
 				.Return(expected)
 				.OK();
 

--- a/src/HttpMock.Integration.Tests/TestContextExtension.cs
+++ b/src/HttpMock.Integration.Tests/TestContextExtension.cs
@@ -1,0 +1,42 @@
+﻿using NUnit.Framework;
+
+namespace HttpMock.Integration.Tests
+{
+    public static class TestContextExtension
+    {
+        private const string HostKey = "HostURL";
+        private const string EndpointToHitKey = "EndpointToHit";
+        private const string HttpMockKey = "HttpMock";
+
+        public static string GetCurrentHostUrl(this TestContext testContext)
+        {
+            return (string)testContext.Test.Properties.Get(HostKey);
+        }
+
+        public static void SetCurrentHostUrl(this TestContext testContext, string hostUrl)
+        {
+            testContext.Test.Properties.Add(HostKey, hostUrl);
+        }
+
+        public static string GetCurrentEndpointToHit(this TestContext testContext)
+        {
+            return (string)testContext.Test.Properties.Get(EndpointToHitKey);
+        }
+
+        public static void SetCurrentEndpointToHit(this TestContext testContext, string endpointToHit)
+        {
+            testContext.Test.Properties.Add(EndpointToHitKey, endpointToHit);
+        }
+
+
+        public static IHttpServer GetCurrentHttpMock(this TestContext testContext)
+        {
+            return (IHttpServer)testContext.Test.Properties.Get(HttpMockKey);
+        }
+
+        public static void SetCurrentHttpMock(this TestContext testContext, IHttpServer httpMock)
+        {
+            testContext.Test.Properties.Add(HttpMockKey, httpMock);
+        }
+    }
+}

--- a/src/HttpMock.Integration.Tests/UsingMultipleServersTests.cs
+++ b/src/HttpMock.Integration.Tests/UsingMultipleServersTests.cs
@@ -3,23 +3,24 @@ using NUnit.Framework;
 
 namespace HttpMock.Integration.Tests
 {
-	[TestFixture]
-	public class UsingMultipleServersTests
-	{
-		[Test, Repeat(3)]
-		public void Should_stubs_on_different_ports_each_time()
-		{
-			string expected = "expected response";
-			var hostUrl = HostHelper.GenerateAHostUrlForAStubServerWith("app");
+    [TestFixture]
+    public class UsingMultipleServersTests
+    {
+        [Test, Repeat(3)]
+        public void Should_stubs_on_different_ports_each_time()
+        {
+            string expected = "expected response";
+            var hostUrl = HostHelper.GenerateAHostUrlForAStubServerWith("app");
 
-			HttpMockRepository.At(hostUrl)
-				.Stub(x => x.Get("/app/endpoint"))
-				.Return(expected)
-				.OK();
+            var stubHttp = HttpMockRepository.At(hostUrl);
+            stubHttp.IsAvailable();
+            stubHttp.Stub(x => x.Get("/app/endpoint"))
+            .Return(expected)
+            .OK();
 
-			WebClient wc = new WebClient();
+            WebClient wc = new WebClient();
 
-			Assert.That(wc.DownloadString(string.Format("{0}/endpoint", hostUrl)), Is.EqualTo(expected));
-		}
-	}
+            Assert.That(wc.DownloadString(string.Format("{0}/endpoint", hostUrl)), Is.EqualTo(expected));
+        }
+    }
 }

--- a/src/HttpMock.Integration.Tests/UsingTheSameStubServerAndDifferentQueryRequestParams.cs
+++ b/src/HttpMock.Integration.Tests/UsingTheSameStubServerAndDifferentQueryRequestParams.cs
@@ -6,85 +6,90 @@ using NUnit.Framework;
 
 namespace HttpMock.Integration.Tests
 {
-	[TestFixture]
-	public class UsingTheSameStubServerAndDifferentQueryRequestParams
-	{
-		private string _endpointToHit;
-		private IHttpServer _httpMockRepository;
+    [TestFixture]
+    public class UsingTheSameStubServerAndDifferentQueryRequestParams
+    {
+        //private string _endpointToHit;
+        //private IHttpServer _httpMockRepository;
 
-		private readonly IDictionary<string, string> _firstSetOfParams = new Dictionary<string, string>
-		{
-			{"trackId", "1"},
-			{"formatId", "1"}
-		};
+        private readonly IDictionary<string, string> _firstSetOfParams = new Dictionary<string, string>
+        {
+            {"trackId", "1"},
+            {"formatId", "1"}
+        };
 
-		private readonly IDictionary<string, string> _secondSetOfParams = new Dictionary<string, string>
-		{
-			{"trackId", "2"},
-			{"formatId", "2"}
-		};
+        private readonly IDictionary<string, string> _secondSetOfParams = new Dictionary<string, string>
+        {
+            {"trackId", "2"},
+            {"formatId", "2"}
+        };
 
-		private readonly IDictionary<string, string> _thirdSetOfParams = new Dictionary<string, string>
-		{
-			{"trackId", "3"},
-			{"formatId", "3"}
-		};
+        private readonly IDictionary<string, string> _thirdSetOfParams = new Dictionary<string, string>
+        {
+            {"trackId", "3"},
+            {"formatId", "3"}
+        };
 
-		[SetUp]
-		public void SetUp()
-		{
-			var hostUrl = HostHelper.GenerateAHostUrlForAStubServer();
-			_endpointToHit = hostUrl + "/endpoint";
-			_httpMockRepository = HttpMockRepository.At(hostUrl);
-		}
+        [SetUp]
+        public void SetUp()
+        {
+            var hostUrl = HostHelper.GenerateAHostUrlForAStubServer();
+            TestContext.CurrentContext.SetCurrentHostUrl(hostUrl);
+            var endpointToHit = hostUrl + "/endpoint";
+            TestContext.CurrentContext.SetCurrentEndpointToHit(endpointToHit);
+            TestContext.CurrentContext.SetCurrentHttpMock(HttpMockRepository.At(hostUrl));
+        }
 
-		[Test]
-		public void Should_return_first_one()
-		{
-			_httpMockRepository.Stub(x => x.Get("/endpoint"))
-				.WithParams(_firstSetOfParams)
-				.Return("I was the first one")
-				.OK();
+        [Test]
+        public void Should_return_first_one()
+        {
+            var _httpMockRepository = TestContext.CurrentContext.GetCurrentHttpMock();
+            _httpMockRepository.Stub(x => x.Get("/endpoint"))
+                .WithParams(_firstSetOfParams)
+                .Return("I was the first one")
+                .OK();
 
-			AssertResponse("I was the first one", _firstSetOfParams);
-		}
+            AssertResponse("I was the first one", _firstSetOfParams);
+        }
 
-		[Test]
-		public void Should_return_second_one()
-		{
-			_httpMockRepository.Stub(x => x.Get("/endpoint"))
-				.WithParams(_secondSetOfParams)
-				.Return("I was the second one")
-				.OK();
+        [Test]
+        public void Should_return_second_one()
+        {
+            var _httpMockRepository = TestContext.CurrentContext.GetCurrentHttpMock();
+            _httpMockRepository.Stub(x => x.Get("/endpoint"))
+                .WithParams(_secondSetOfParams)
+                .Return("I was the second one")
+                .OK();
 
-			AssertResponse("I was the second one", _secondSetOfParams);
-		}
+            AssertResponse("I was the second one", _secondSetOfParams);
+        }
 
-		[Test]
-		public void Should_return_third_one()
-		{
-			_httpMockRepository.Stub(x => x.Get("/endpoint"))
-				.WithParams(_thirdSetOfParams)
-				.Return("I was the third one")
-				.OK();
+        [Test]
+        public void Should_return_third_one()
+        {
+            var _httpMockRepository = TestContext.CurrentContext.GetCurrentHttpMock();
+            _httpMockRepository.Stub(x => x.Get("/endpoint"))
+                .WithParams(_thirdSetOfParams)
+                .Return("I was the third one")
+                .OK();
 
-			AssertResponse("I was the third one", _thirdSetOfParams);
-		}
+            AssertResponse("I was the third one", _thirdSetOfParams);
+        }
 
-		private void AssertResponse(string expected, IEnumerable<KeyValuePair<string, string>> queryString)
-		{
-			string aggregate = queryString.Select(x => x.Key + "=" + x.Value + "&").Aggregate((a, b) => a + b).Trim('&');
-
-			var webRequest =
-				(HttpWebRequest) WebRequest.Create(string.Format("{0}?{1}&abirdinthehand=twointhebush", _endpointToHit, aggregate));
-			using (var response = webRequest.GetResponse())
-			{
-				using (var sr = new StreamReader(response.GetResponseStream()))
-				{
-					string readToEnd = sr.ReadToEnd();
-					Assert.That(readToEnd, Is.EqualTo(expected));
-				}
-			}
-		}
-	}
+        private void AssertResponse(string expected, IEnumerable<KeyValuePair<string, string>> queryString)
+        {
+            string aggregate = queryString.Select(x => x.Key + "=" + x.Value + "&").Aggregate((a, b) => a + b).Trim('&');
+            string endpointToHit = TestContext.CurrentContext.GetCurrentEndpointToHit();
+            var webRequest =
+                (HttpWebRequest)WebRequest.Create(string.Format("{0}?{1}&abirdinthehand=twointhebush", endpointToHit, aggregate));
+            using (var response = webRequest.GetResponse())
+            {
+                using (var sr = new StreamReader(response.GetResponseStream()))
+                {
+                    string readToEnd = sr.ReadToEnd();
+                    Assert.That(readToEnd, Is.EqualTo(expected));
+                }
+            }
+        }
+    }
 }

--- a/src/HttpMock.Integration.Tests/UsingTheSameStubServerAndDifferentRequestHeaders.cs
+++ b/src/HttpMock.Integration.Tests/UsingTheSameStubServerAndDifferentRequestHeaders.cs
@@ -5,85 +5,87 @@ using NUnit.Framework;
 
 namespace HttpMock.Integration.Tests
 {
-	[TestFixture]
-	public class UsingTheSameStubServerAndDifferentRequestHeaders
-	{
-		private string _endpointToHit;
-		private IHttpServer _httpMockRepository;
+    [TestFixture]
+    public class UsingTheSameStubServerAndDifferentRequestHeaders
+    {
+        private readonly IDictionary<string, string> _firstSetOfHeaders = new Dictionary<string, string>
+        {
+            {"X-HeaderOne", "one"},
+            {"X-HeaderTwo", "a"}
+        };
 
-		private readonly IDictionary<string, string> _firstSetOfHeaders = new Dictionary<string, string>
-		{
-			{"X-HeaderOne", "one"},
-			{"X-HeaderTwo", "a"}
-		};
+        private readonly IDictionary<string, string> _secondSetOfHeaders = new Dictionary<string, string>
+        {
+            {"X-HeaderOne", "one"},
+            {"X-HeaderTwo", "b"}
+        };
 
-		private readonly IDictionary<string, string> _secondSetOfHeaders = new Dictionary<string, string>
-		{
-			{"X-HeaderOne", "one"},
-			{"X-HeaderTwo", "b"}
-		};
+        private readonly IDictionary<string, string> _thirdSetOfHeaders = new Dictionary<string, string>
+        {
+            {"X-HeaderOne", "two"},
+            {"X-HeaderTwo", "a"}
+        };
 
-		private readonly IDictionary<string, string> _thirdSetOfHeaders = new Dictionary<string, string>
-		{
-			{"X-HeaderOne", "two"},
-			{"X-HeaderTwo", "a"}
-		};
+        [SetUp]
+        public void SetUp()
+        {
+            var hostUrl = HostHelper.GenerateAHostUrlForAStubServer();
+            TestContext.CurrentContext.SetCurrentHostUrl(hostUrl);
+            var endpointToHit = hostUrl + "/endpoint";
+            TestContext.CurrentContext.SetCurrentEndpointToHit(endpointToHit);
+            TestContext.CurrentContext.SetCurrentHttpMock(HttpMockRepository.At(hostUrl));
 
-		[SetUp]
-		public void SetUp()
-		{
-			var hostUrl = HostHelper.GenerateAHostUrlForAStubServer();
-			_endpointToHit = hostUrl + "/endpoint";
-			_httpMockRepository = HttpMockRepository.At(hostUrl);
+            var httpMockRepository = TestContext.CurrentContext.GetCurrentHttpMock();
 
-			_httpMockRepository.Stub(x => x.Get("/endpoint"))
-				.WithHeaders(_firstSetOfHeaders)
-				.Return("I was the first one")
-				.OK();
-			_httpMockRepository.Stub(x => x.Get("/endpoint"))
-				.WithHeaders(_secondSetOfHeaders)
-				.Return("I was the second one")
-				.OK();
-			_httpMockRepository.Stub(x => x.Get("/endpoint"))
-				.WithHeaders(_thirdSetOfHeaders)
-				.Return("I was the third one")
-				.OK();
-		}
 
-		[Test]
-		public void Should_return_first_one()
-		{
-			AssertResponse("I was the first one", _firstSetOfHeaders);
-		}
+            httpMockRepository.Stub(x => x.Get("/endpoint"))
+                .WithHeaders(_firstSetOfHeaders)
+                .Return("I was the first one")
+                .OK();
+            httpMockRepository.Stub(x => x.Get("/endpoint"))
+                .WithHeaders(_secondSetOfHeaders)
+                .Return("I was the second one")
+                .OK();
+            httpMockRepository.Stub(x => x.Get("/endpoint"))
+                .WithHeaders(_thirdSetOfHeaders)
+                .Return("I was the third one")
+                .OK();
+        }
 
-		[Test]
-		public void Should_return_second_one()
-		{
-			AssertResponse("I was the second one", _secondSetOfHeaders);
-		}
+        [Test]
+        public void Should_return_first_one()
+        {
+            AssertResponse("I was the first one", _firstSetOfHeaders);
+        }
 
-		[Test]
-		public void Should_return_third_one()
-		{
-			AssertResponse("I was the third one", _thirdSetOfHeaders);
-		}
+        [Test]
+        public void Should_return_second_one()
+        {
+            AssertResponse("I was the second one", _secondSetOfHeaders);
+        }
 
-		private void AssertResponse(string expected, IEnumerable<KeyValuePair<string, string>> headers)
-		{
-			var webRequest =
-				(HttpWebRequest) WebRequest.Create(string.Format("{0}?abirdinthehand=twointhebush", _endpointToHit));
-			foreach (var header in headers)
-			{
-				webRequest.Headers.Add(header.Key, header.Value);
-			}
-			using (var response = webRequest.GetResponse())
-			{
-				using (var sr = new StreamReader(response.GetResponseStream()))
-				{
-					var readToEnd = sr.ReadToEnd();
-					Assert.That(readToEnd, Is.EqualTo(expected));
-				}
-			}
-		}
-	}
+        [Test]
+        public void Should_return_third_one()
+        {
+            AssertResponse("I was the third one", _thirdSetOfHeaders);
+        }
+
+        private void AssertResponse(string expected, IEnumerable<KeyValuePair<string, string>> headers)
+        {
+            var webRequest =
+                (HttpWebRequest)WebRequest.Create(string.Format("{0}?abirdinthehand=twointhebush", TestContext.CurrentContext.GetCurrentEndpointToHit()));
+            foreach (var header in headers)
+            {
+                webRequest.Headers.Add(header.Key, header.Value);
+            }
+            using (var response = webRequest.GetResponse())
+            {
+                using (var sr = new StreamReader(response.GetResponseStream()))
+                {
+                    var readToEnd = sr.ReadToEnd();
+                    Assert.That(readToEnd, Is.EqualTo(expected));
+                }
+            }
+        }
+    }
 }

--- a/src/HttpMock.Integration.Tests/packages.config
+++ b/src/HttpMock.Integration.Tests/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Kayak" version="0.7.2" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
-  <package id="NUnit" version="3.6.1" targetFramework="net45" />
+  <package id="NUnit" version="3.8.1" targetFramework="net45" />
   <package id="RhinoMocks" version="3.6.1" requireReinstallation="True" />
 </packages>

--- a/src/HttpMock.Unit.Tests/HttpMock.Unit.Tests.csproj
+++ b/src/HttpMock.Unit.Tests/HttpMock.Unit.Tests.csproj
@@ -70,6 +70,9 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/HttpMock.Unit.Tests/HttpMock.Unit.Tests.csproj
+++ b/src/HttpMock.Unit.Tests/HttpMock.Unit.Tests.csproj
@@ -37,8 +37,9 @@
     <Reference Include="Kayak">
       <HintPath>..\..\packages\Kayak.0.7.2\lib\Kayak.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb">
-      <HintPath>..\..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/HttpMock.Unit.Tests/RequestProcessorTests.cs
+++ b/src/HttpMock.Unit.Tests/RequestProcessorTests.cs
@@ -1,144 +1,145 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Kayak;
 using Kayak.Http;
 using NUnit.Framework;
 using Rhino.Mocks;
 
-namespace HttpMock.Unit.Tests {
-	[TestFixture]
-	public class RequestProcessorTests
-	{
-		private RequestProcessor _processor;
-		private IDataProducer _dataProducer;
-		private IHttpResponseDelegate _httpResponseDelegate;
-		private IMatchingRule _ruleThatReturnsFirstHandler;
-		private IMatchingRule _ruleThatReturnsNoHandlers;
-		private RequestHandlerFactory _requestHandlerFactory;
+namespace HttpMock.Unit.Tests
+{
+    [TestFixture]
+    public class RequestProcessorTests
+    {
+        private RequestProcessor _processor;
+        private IDataProducer _dataProducer;
+        private IHttpResponseDelegate _httpResponseDelegate;
+        private IMatchingRule _ruleThatReturnsFirstHandler;
+        private IMatchingRule _ruleThatReturnsNoHandlers;
+        private RequestHandlerFactory _requestHandlerFactory;
 
-		[SetUp]
-		public void SetUp() {
-			_processor = new RequestProcessor(_ruleThatReturnsFirstHandler, new RequestHandlerList());
-			_requestHandlerFactory = new RequestHandlerFactory(_processor);
-			_dataProducer = MockRepository.GenerateStub<IDataProducer>();
-			_httpResponseDelegate = MockRepository.GenerateStub<IHttpResponseDelegate>();
+        [SetUp]
+        public void SetUp() {
+            _processor = new RequestProcessor(_ruleThatReturnsFirstHandler, new ConcurrentDictionary<Guid, RequestHandlerList>());
+            _requestHandlerFactory = new RequestHandlerFactory(_processor);
+            _dataProducer = MockRepository.GenerateStub<IDataProducer>();
+            _httpResponseDelegate = MockRepository.GenerateStub<IHttpResponseDelegate>();
 
-			_ruleThatReturnsFirstHandler = MockRepository.GenerateStub<IMatchingRule>();
-			_ruleThatReturnsFirstHandler.Stub(x => x.IsEndpointMatch(null, new HttpRequestHead())).IgnoreArguments().Return(true).Repeat.Once();
+            _ruleThatReturnsFirstHandler = MockRepository.GenerateStub<IMatchingRule>();
+            _ruleThatReturnsFirstHandler.Stub(x => x.IsEndpointMatch(null, new HttpRequestHead())).IgnoreArguments().Return(true).Repeat.Once();
 
-			_ruleThatReturnsNoHandlers = MockRepository.GenerateStub<IMatchingRule>();
-			_ruleThatReturnsNoHandlers.Stub(x => x.IsEndpointMatch(null, new HttpRequestHead())).IgnoreArguments().Return(false);
-		}
-
-		[Test]
-		public void Get_should_return_handler_with_get_method_set() {
-			RequestHandler requestHandler = _requestHandlerFactory.Get("nowhere");
-			Assert.That(requestHandler.Method, Is.EqualTo("GET"));
-		}
-
-		[Test]
-		public void Post_should_return_handler_with_post_method_set() {
-			RequestHandler requestHandler = _requestHandlerFactory.Post("nowhere");
-			Assert.That(requestHandler.Method, Is.EqualTo("POST"));
-		}
-
-		[Test]
-		public void Put_should_return_handler_with_put_method_set() {
-			RequestHandler requestHandler = _requestHandlerFactory.Put("nowhere");
-			Assert.That(requestHandler.Method, Is.EqualTo("PUT"));
-		}
-
-		[Test]
-		public void Delete_should_return_handler_with_delete_method_set() {
-			RequestHandler requestHandler = _requestHandlerFactory.Delete("nowhere");
-			Assert.That(requestHandler.Method, Is.EqualTo("DELETE"));
-		}
-
-		[Test]
-		public void Head_should_return_handler_with_head_method_set() {
-			RequestHandler requestHandler = _requestHandlerFactory.Head("nowhere");
-			Assert.That(requestHandler.Method, Is.EqualTo("HEAD"));
-		}
-
-		[Test]
-		public void Custom_verb_should_return_handler_with_custom_method_set() {
-			RequestHandler requestHandler = _requestHandlerFactory.CustomVerb("nowhere", "PURGE");
-			Assert.That(requestHandler.Method, Is.EqualTo("PURGE"));
-		}
-
-		[Test]
-		public void If_no_handlers_found_should_fire_onresponse_with_a_404() {
-			_processor = new RequestProcessor(_ruleThatReturnsNoHandlers, new RequestHandlerList());
-
-			_processor.Add(_requestHandlerFactory.Get("test"));
-			_processor.OnRequest(new HttpRequestHead(), _dataProducer, _httpResponseDelegate);
-			_httpResponseDelegate.AssertWasCalled(x => x.OnResponse(Arg<HttpResponseHead>.Matches(y => y.Status == "404 NotFound"), Arg<IDataProducer>.Is.Null));
-		}
-
-		[Test]
-		public void If_a_handler_found_should_fire_onresponse_with_that_repsonse() {
-			_processor = new RequestProcessor(_ruleThatReturnsFirstHandler, new RequestHandlerList());
-
-			RequestHandler requestHandler = _requestHandlerFactory.Get("test");
-			_processor.Add(requestHandler);
-			Dictionary<string, string> headers = new Dictionary<string, string>();
-			_processor.OnRequest(new HttpRequestHead{ Headers =  headers}, _dataProducer, _httpResponseDelegate);
-
-			_httpResponseDelegate.AssertWasCalled(
-				x => x.OnResponse(requestHandler.ResponseBuilder.BuildHeaders(), 
-				requestHandler.ResponseBuilder.BuildBody(headers)));
-		}
-		
-		[Test]
-		public void Matching_HEAD_handler_should_output_handlers_expected_response_with_null_body() {
-
-			_processor = new RequestProcessor(_ruleThatReturnsFirstHandler, new RequestHandlerList());
-
-			RequestHandler requestHandler = _requestHandlerFactory.Head("test");
-			_processor.Add(requestHandler);
-			var httpRequestHead = new HttpRequestHead { Method = "HEAD", Headers = new Dictionary<string, string>() };
-			_processor.OnRequest(httpRequestHead, _dataProducer, _httpResponseDelegate);
-
-			_httpResponseDelegate.AssertWasCalled(x => x.OnResponse(requestHandler.ResponseBuilder.BuildHeaders(), null));
-		}
-
-		[Test]
-		public void When_a_handler_is_added_should_be_able_to_find_it() {
-			string expectedPath = "/blah/test";
-			string expectedMethod = "GET";
-
-			var requestProcessor = new RequestProcessor(null, new RequestHandlerList());
-
-			requestProcessor.Add(_requestHandlerFactory.Get(expectedPath));
-
-			var handler = (RequestHandler) requestProcessor.FindHandler(expectedMethod, expectedPath);
-
-			Assert.That(handler.Path, Is.EqualTo(expectedPath));
-			Assert.That(handler.Method, Is.EqualTo(expectedMethod));
-
-		}
-
-		[Test]
-		public void When_a_handler_is_hit_handlers_request_count_is_incremented() {
-
-			string expectedPath = "/blah/test";
-			string expectedMethod = "GET";
-
-			var requestProcessor = new RequestProcessor(_ruleThatReturnsFirstHandler, new RequestHandlerList());
-
-			requestProcessor.Add(_requestHandlerFactory.Get(expectedPath));
-			var httpRequestHead = new HttpRequestHead { Headers = new Dictionary<string, string>() };
-			httpRequestHead.Path = expectedPath;
-			httpRequestHead.Method = expectedPath;
-			requestProcessor.OnRequest(httpRequestHead, _dataProducer, _httpResponseDelegate);
-
-			var handler = requestProcessor.FindHandler(expectedMethod, expectedPath);
-			Assert.That(handler.RequestCount(), Is.EqualTo(1));
-		}
+            _ruleThatReturnsNoHandlers = MockRepository.GenerateStub<IMatchingRule>();
+            _ruleThatReturnsNoHandlers.Stub(x => x.IsEndpointMatch(null, new HttpRequestHead())).IgnoreArguments().Return(false);
+        }
 
         [Test]
-        public void Returns_mock_not_found_when_handler_constraints_cannot_be_verified()
-        {
+        public void Get_should_return_handler_with_get_method_set() {
+            RequestHandler requestHandler = _requestHandlerFactory.Get("nowhere");
+            Assert.That(requestHandler.Method, Is.EqualTo("GET"));
+        }
+
+        [Test]
+        public void Post_should_return_handler_with_post_method_set() {
+            RequestHandler requestHandler = _requestHandlerFactory.Post("nowhere");
+            Assert.That(requestHandler.Method, Is.EqualTo("POST"));
+        }
+
+        [Test]
+        public void Put_should_return_handler_with_put_method_set() {
+            RequestHandler requestHandler = _requestHandlerFactory.Put("nowhere");
+            Assert.That(requestHandler.Method, Is.EqualTo("PUT"));
+        }
+
+        [Test]
+        public void Delete_should_return_handler_with_delete_method_set() {
+            RequestHandler requestHandler = _requestHandlerFactory.Delete("nowhere");
+            Assert.That(requestHandler.Method, Is.EqualTo("DELETE"));
+        }
+
+        [Test]
+        public void Head_should_return_handler_with_head_method_set() {
+            RequestHandler requestHandler = _requestHandlerFactory.Head("nowhere");
+            Assert.That(requestHandler.Method, Is.EqualTo("HEAD"));
+        }
+
+        [Test]
+        public void Custom_verb_should_return_handler_with_custom_method_set() {
+            RequestHandler requestHandler = _requestHandlerFactory.CustomVerb("nowhere", "PURGE");
+            Assert.That(requestHandler.Method, Is.EqualTo("PURGE"));
+        }
+
+        [Test]
+        public void If_no_handlers_found_should_fire_onresponse_with_a_404() {
+            _processor = new RequestProcessor(_ruleThatReturnsNoHandlers, new ConcurrentDictionary<Guid, RequestHandlerList>());
+
+            _processor.Add(_requestHandlerFactory.Get("test"));
+            _processor.OnRequest(new HttpRequestHead(), _dataProducer, _httpResponseDelegate);
+            _httpResponseDelegate.AssertWasCalled(x => x.OnResponse(Arg<HttpResponseHead>.Matches(y => y.Status == "404 NotFound"), Arg<IDataProducer>.Is.Null));
+        }
+
+        [Test]
+        public void If_a_handler_found_should_fire_onresponse_with_that_repsonse() {
+            _processor = new RequestProcessor(_ruleThatReturnsFirstHandler, new ConcurrentDictionary<Guid, RequestHandlerList>());
+
+            RequestHandler requestHandler = _requestHandlerFactory.Get("test");
+            _processor.Add(requestHandler);
+            Dictionary<string, string> headers = new Dictionary<string, string>();
+            _processor.OnRequest(new HttpRequestHead { Headers = headers }, _dataProducer, _httpResponseDelegate);
+
+            _httpResponseDelegate.AssertWasCalled(
+                x => x.OnResponse(requestHandler.ResponseBuilder.BuildHeaders(),
+                requestHandler.ResponseBuilder.BuildBody(headers)));
+        }
+
+        [Test]
+        public void Matching_HEAD_handler_should_output_handlers_expected_response_with_null_body() {
+
+            _processor = new RequestProcessor(_ruleThatReturnsFirstHandler, new ConcurrentDictionary<Guid, RequestHandlerList>());
+
+            RequestHandler requestHandler = _requestHandlerFactory.Head("test");
+            _processor.Add(requestHandler);
+            var httpRequestHead = new HttpRequestHead { Method = "HEAD", Headers = new Dictionary<string, string>() };
+            _processor.OnRequest(httpRequestHead, _dataProducer, _httpResponseDelegate);
+
+            _httpResponseDelegate.AssertWasCalled(x => x.OnResponse(requestHandler.ResponseBuilder.BuildHeaders(), null));
+        }
+
+        [Test]
+        public void When_a_handler_is_added_should_be_able_to_find_it() {
+            string expectedPath = "/blah/test";
+            string expectedMethod = "GET";
+
+            var requestProcessor = new RequestProcessor(null, new ConcurrentDictionary<Guid, RequestHandlerList>());
+
+            requestProcessor.Add(_requestHandlerFactory.Get(expectedPath));
+
+            var handler = (RequestHandler)requestProcessor.FindHandler(expectedMethod, expectedPath);
+
+            Assert.That(handler.Path, Is.EqualTo(expectedPath));
+            Assert.That(handler.Method, Is.EqualTo(expectedMethod));
+
+        }
+
+        [Test]
+        public void When_a_handler_is_hit_handlers_request_count_is_incremented() {
+
+            string expectedPath = "/blah/test";
+            string expectedMethod = "GET";
+
+            var requestProcessor = new RequestProcessor(_ruleThatReturnsFirstHandler, new ConcurrentDictionary<Guid, RequestHandlerList>());
+
+            requestProcessor.Add(_requestHandlerFactory.Get(expectedPath));
+            var httpRequestHead = new HttpRequestHead { Headers = new Dictionary<string, string>() };
+            httpRequestHead.Path = expectedPath;
+            httpRequestHead.Method = expectedPath;
+            requestProcessor.OnRequest(httpRequestHead, _dataProducer, _httpResponseDelegate);
+
+            var handler = requestProcessor.FindHandler(expectedMethod, expectedPath);
+            Assert.That(handler.RequestCount(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Returns_mock_not_found_when_handler_constraints_cannot_be_verified() {
             var excludePhrase = "OhMyDaysssss";
 
             var handlerWithConstraints = new RequestHandler("", null);
@@ -146,16 +147,20 @@ namespace HttpMock.Unit.Tests {
 
             var matchingRule = MockRepository.GenerateMock<IMatchingRule>();
             matchingRule.Stub(m => m.IsEndpointMatch(Arg<IRequestHandler>.Is.Anything, Arg<HttpRequestHead>.Is.Anything)).Return(true);
-            
-            var p = new RequestProcessor(matchingRule, new RequestHandlerList { handlerWithConstraints });
+
+            ConcurrentDictionary<Guid, RequestHandlerList> lst = new ConcurrentDictionary<Guid, RequestHandlerList>();
+            RequestHandlerList rList = new RequestHandlerList();
+            rList.Add(handlerWithConstraints);
+            lst.GetOrAdd(Guid.Empty, rList);
+            var p = new RequestProcessor(matchingRule, lst);
 
             var response = MockRepository.GenerateMock<IHttpResponseDelegate>();
-            p.OnRequest(new HttpRequestHead{Uri = "http://blah.com/cheese/" + excludePhrase}, null, response);
+            p.OnRequest(new HttpRequestHead { Uri = "http://blah.com/cheese/" + excludePhrase }, null, response);
 
             var notFoundResponse = (HttpResponseHead)response.GetArgumentsForCallsMadeOn(
                 r => r.OnResponse(Arg<HttpResponseHead>.Is.Anything, Arg<IDataProducer>.Is.Anything))[0][0];
 
-            Assert.That(notFoundResponse.Status  == "404 NotFound");
+            Assert.That(notFoundResponse.Status == "404 NotFound");
         }
-	}
+    }
 }

--- a/src/HttpMock.Unit.Tests/packages.config
+++ b/src/HttpMock.Unit.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Kayak" version="0.7.2" />
-  <package id="NUnit" version="3.6.1" targetFramework="net45" />
+  <package id="NUnit" version="3.8.1" targetFramework="net45" />
   <package id="RhinoMocks" version="3.6.1" requireReinstallation="True" />
 </packages>

--- a/src/HttpMock.Verify.NUnit/HttpMock.Verify.NUnit.csproj
+++ b/src/HttpMock.Verify.NUnit/HttpMock.Verify.NUnit.csproj
@@ -32,11 +32,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Kayak, Version=0.7.2.0, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="Kayak, Version=0.7.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Kayak.0.7.2\lib\Kayak.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb">
-      <HintPath>..\..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -58,6 +60,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="HttpMock.Verify.NUnit.nuspec" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/HttpMock.Verify.NUnit/HttpServerExtensions.cs
+++ b/src/HttpMock.Verify.NUnit/HttpServerExtensions.cs
@@ -2,18 +2,18 @@
 
 namespace HttpMock.Verify.NUnit
 {
-	public static class HttpServerExtensions
-	{
+    public static class HttpServerExtensions
+    {
 
 
-		public static IRequestVerify AssertWasCalled(this IHttpServer httpServer,Func<RequestWasCalled, IRequestVerify> func)
-		{
-			return func.Invoke(new RequestWasCalled(httpServer.GetRequestProcessor()));
-		}
+        public static IRequestVerify AssertWasCalled(this IHttpServer httpServer, Func<RequestWasCalled, IRequestVerify> func, Guid sessionId = default(Guid))
+        {
+            return func.Invoke(new RequestWasCalled(httpServer.GetRequestProcessor(), sessionId));
+        }
 
-		public static IRequestVerify AssertWasNotCalled(this IHttpServer httpServer, Func<RequestWasNotCalled, IRequestVerify> func)
-		{
-			return func.Invoke(new RequestWasNotCalled(httpServer.GetRequestProcessor()));
-		}
-	}
+        public static IRequestVerify AssertWasNotCalled(this IHttpServer httpServer, Func<RequestWasNotCalled, IRequestVerify> func, Guid sessionId = default(Guid))
+        {
+            return func.Invoke(new RequestWasNotCalled(httpServer.GetRequestProcessor(), sessionId));
+        }
+    }
 }

--- a/src/HttpMock.Verify.NUnit/RequestWasCalled.cs
+++ b/src/HttpMock.Verify.NUnit/RequestWasCalled.cs
@@ -6,9 +6,10 @@ namespace HttpMock.Verify.NUnit
 	public class RequestWasCalled
 	{
 		private readonly IRequestProcessor _requestProcessor;
-
-		public RequestWasCalled(IRequestProcessor requestProcessor) {
+	    private readonly Guid _sessionId;
+		public RequestWasCalled(IRequestProcessor requestProcessor, Guid sessionId = default(Guid)) {
 			_requestProcessor = requestProcessor;
+		    _sessionId = sessionId;
 		}
 
 		public IRequestVerify Get(string path)
@@ -16,8 +17,8 @@ namespace HttpMock.Verify.NUnit
 			return AssertHandler("GET", path);
 		}
 
-		private IRequestVerify AssertHandler(string method, string path, Guid sessionId=default(Guid)) {
-			var handler = _requestProcessor.FindHandler(method, path, sessionId);
+		private IRequestVerify AssertHandler(string method, string path) {
+			var handler = _requestProcessor.FindHandler(method, path, _sessionId);
 			Assert.That(handler, Is.Not.Null, string.Format("Handler for path {0} and method {1} was not stubbed", path, method));
 			Assert.That(handler.RequestCount(), Is.GreaterThan(0), string.Format("Handler for path {0} and method {1} was never called", path, method));
 			return handler;

--- a/src/HttpMock.Verify.NUnit/RequestWasCalled.cs
+++ b/src/HttpMock.Verify.NUnit/RequestWasCalled.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 
 namespace HttpMock.Verify.NUnit
@@ -15,8 +16,8 @@ namespace HttpMock.Verify.NUnit
 			return AssertHandler("GET", path);
 		}
 
-		private IRequestVerify AssertHandler(string method, string path) {
-			var handler = _requestProcessor.FindHandler(method, path);
+		private IRequestVerify AssertHandler(string method, string path, Guid sessionId=default(Guid)) {
+			var handler = _requestProcessor.FindHandler(method, path, sessionId);
 			Assert.That(handler, Is.Not.Null, string.Format("Handler for path {0} and method {1} was not stubbed", path, method));
 			Assert.That(handler.RequestCount(), Is.GreaterThan(0), string.Format("Handler for path {0} and method {1} was never called", path, method));
 			return handler;

--- a/src/HttpMock.Verify.NUnit/RequestWasNotCalled.cs
+++ b/src/HttpMock.Verify.NUnit/RequestWasNotCalled.cs
@@ -3,51 +3,59 @@ using NUnit.Framework;
 
 namespace HttpMock.Verify.NUnit
 {
-	public class RequestWasNotCalled
-	{
-		private readonly IRequestProcessor _requestProcessor;
+    public class RequestWasNotCalled
+    {
+        private readonly IRequestProcessor _requestProcessor;
+        private readonly Guid _sessionId;
 
-		public RequestWasNotCalled(IRequestProcessor requestProcessor) {
-			_requestProcessor = requestProcessor;
-		}
+        public RequestWasNotCalled(IRequestProcessor requestProcessor, Guid sessionId = default(Guid))
+        {
+            _requestProcessor = requestProcessor;
+            _sessionId = sessionId;
+        }
 
-		public IRequestVerify Get(string path)
-		{
-			return AssertHandler( "GET", path);
-		}
+        public IRequestVerify Get(string path)
+        {
+            return AssertHandler("GET", path);
+        }
 
-		private IRequestVerify AssertHandler(string method, string path, Guid sessionId = default(Guid)) {
-			var handler = _requestProcessor.FindHandler(method, path, sessionId);
-			if (handler != null) {
-				Assert.That(handler.RequestCount(), Is.EqualTo(0), "Expected not to find a request for {1}{0} but was found", method, path);
-			}else {
-				Assert.That(handler, Is.Null, "Expected not to find a request for {1}{0} but was found", method, path);
-			}
-			return handler;
-		}
+        private IRequestVerify AssertHandler(string method, string path)
+        {
+            var handler = _requestProcessor.FindHandler(method, path, _sessionId);
+            if (handler != null)
+            {
+                Assert.That(handler.RequestCount(), Is.EqualTo(0), "Expected not to find a request for {1}{0} but was found", method, path);
+            }
+            else
+            {
+                Assert.That(handler, Is.Null, "Expected not to find a request for {1}{0} but was found", method, path);
+            }
+            return handler;
+        }
 
-		public IRequestVerify Post(string path) {
-			return CustomVerb("POST", path);
-		}
+        public IRequestVerify Post(string path)
+        {
+            return CustomVerb("POST", path);
+        }
 
-		public IRequestVerify Put(string path)
-		{
-			return CustomVerb("PUT", path);
-		}
+        public IRequestVerify Put(string path)
+        {
+            return CustomVerb("PUT", path);
+        }
 
-		public IRequestVerify Delete(string path)
-		{
-			return CustomVerb( "DELETE", path);
-		}
+        public IRequestVerify Delete(string path)
+        {
+            return CustomVerb("DELETE", path);
+        }
 
-		public IRequestVerify Head(string path)
-		{
-			return CustomVerb( "HEAD", path);
-		}
+        public IRequestVerify Head(string path)
+        {
+            return CustomVerb("HEAD", path);
+        }
 
-		public IRequestVerify CustomVerb(string verb, string path)
-		{
-			return AssertHandler(verb, path);
-		}
-	}
+        public IRequestVerify CustomVerb(string verb, string path)
+        {
+            return AssertHandler(verb, path);
+        }
+    }
 }

--- a/src/HttpMock.Verify.NUnit/RequestWasNotCalled.cs
+++ b/src/HttpMock.Verify.NUnit/RequestWasNotCalled.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 
 namespace HttpMock.Verify.NUnit
@@ -15,8 +16,8 @@ namespace HttpMock.Verify.NUnit
 			return AssertHandler( "GET", path);
 		}
 
-		private IRequestVerify AssertHandler(string method, string path) {
-			var handler = _requestProcessor.FindHandler(method, path);
+		private IRequestVerify AssertHandler(string method, string path, Guid sessionId = default(Guid)) {
+			var handler = _requestProcessor.FindHandler(method, path, sessionId);
 			if (handler != null) {
 				Assert.That(handler.RequestCount(), Is.EqualTo(0), "Expected not to find a request for {1}{0} but was found", method, path);
 			}else {

--- a/src/HttpMock.Verify.NUnit/packages.config
+++ b/src/HttpMock.Verify.NUnit/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Kayak" version="0.7.2" targetFramework="net45" />
+  <package id="NUnit" version="3.8.1" targetFramework="net45" />
+</packages>

--- a/src/HttpMock/Constants.cs
+++ b/src/HttpMock/Constants.cs
@@ -1,0 +1,8 @@
+﻿namespace HttpMock
+{
+    class Constants
+    {
+        public const string MockSessionHeaderKey = "Mock-SessionID";
+        public const string CookieHeaderKey = "Cookie";
+    }
+}

--- a/src/HttpMock/Constants.cs
+++ b/src/HttpMock/Constants.cs
@@ -1,6 +1,6 @@
 ﻿namespace HttpMock
 {
-    class Constants
+    public class Constants
     {
         public const string MockSessionHeaderKey = "Mock-SessionID";
         public const string CookieHeaderKey = "Cookie";

--- a/src/HttpMock/HttpMock.csproj
+++ b/src/HttpMock/HttpMock.csproj
@@ -47,6 +47,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Constants.cs" />
     <Compile Include="ILog.cs" />
     <Compile Include="IRequestProcessor.cs" />
     <Compile Include="IRequestVerify.cs" />

--- a/src/HttpMock/HttpMockRepository.cs
+++ b/src/HttpMock/HttpMockRepository.cs
@@ -16,7 +16,7 @@ namespace HttpMock
 
 		public static IHttpServer At(Uri uri)
 		{
-			return _httpServerFactory.Get(uri).WithNewContext();
+			return _httpServerFactory.Get(uri).WithNewContext(Guid.Empty);
 		}
 	}
 }

--- a/src/HttpMock/HttpServer.cs
+++ b/src/HttpMock/HttpServer.cs
@@ -40,7 +40,7 @@ namespace HttpMock
 
         public bool IsAvailable()
         {
-            const int timesToWait = 5;
+            const int timesToWait = 10;
             var attempts = 0;
             using (var tcpClient = new TcpClient())
             {

--- a/src/HttpMock/HttpServer.cs
+++ b/src/HttpMock/HttpServer.cs
@@ -5,126 +5,127 @@ using System.Reflection;
 using System.Threading;
 using Kayak;
 using Kayak.Http;
+using System.Collections.Concurrent;
 
 namespace HttpMock
 {
-	public class HttpServer : IHttpServer
-	{
-		private static readonly ILog _log = LogFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-		private readonly RequestHandlerFactory _requestHandlerFactory;
-		private readonly IRequestProcessor _requestProcessor;
-		private readonly IScheduler _scheduler;
-		private readonly Uri _uri;
-		private IDisposable _disposableServer;
-		private Thread _thread;
+    public class HttpServer : IHttpServer
+    {
+        private static readonly ILog _log = LogFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private readonly RequestHandlerFactory _requestHandlerFactory;
+        private readonly IRequestProcessor _requestProcessor;
+        private readonly IScheduler _scheduler;
+        private readonly Uri _uri;
+        private IDisposable _disposableServer;
+        private Thread _thread;
 
-		public HttpServer(Uri uri)
-		{
-			_uri = uri;
-			_scheduler = KayakScheduler.Factory.Create(new SchedulerDelegate());
-			_requestProcessor = new RequestProcessor(new EndpointMatchingRule(), new RequestHandlerList());
+        public HttpServer(Uri uri)
+        {
+            _uri = uri;
+            _scheduler = KayakScheduler.Factory.Create(new SchedulerDelegate());
+            _requestProcessor = new RequestProcessor(new EndpointMatchingRule(), new ConcurrentDictionary<Guid, RequestHandlerList>());
 
-			_requestHandlerFactory = new RequestHandlerFactory(_requestProcessor);
-		}
+            _requestHandlerFactory = new RequestHandlerFactory(_requestProcessor);
+        }
 
-		public void Start()
-		{
-			_thread = new Thread(StartListening);
-			_thread.Start();
-			if (!IsAvailable())
-			{
-				throw new InvalidOperationException("Kayak server not listening yet.");
-			}
-		}
+        public void Start()
+        {
+            _thread = new Thread(StartListening);
+            _thread.Start();
+            if (!IsAvailable())
+            {
+                throw new InvalidOperationException("Kayak server not listening yet.");
+            }
+        }
 
-		public bool IsAvailable()
-		{
-			const int timesToWait = 5;
-			var attempts = 0;
-			using (var tcpClient = new TcpClient())
-			{
-				while (attempts < timesToWait)
-				{
-					try
-					{
-						tcpClient.Connect(_uri.Host, _uri.Port);
-						return tcpClient.Connected;
-					}
-					catch (SocketException)
-					{
-					}
+        public bool IsAvailable()
+        {
+            const int timesToWait = 5;
+            var attempts = 0;
+            using (var tcpClient = new TcpClient())
+            {
+                while (attempts < timesToWait)
+                {
+                    try
+                    {
+                        tcpClient.Connect(_uri.Host, _uri.Port);
+                        return tcpClient.Connected;
+                    }
+                    catch (SocketException)
+                    {
+                    }
 
-					Thread.Sleep(100);
-					attempts++;
-				}
-				return false;
-			}
-		}
+                    Thread.Sleep(100);
+                    attempts++;
+                }
+                return false;
+            }
+        }
 
-		public IRequestProcessor GetRequestProcessor()
-		{
-			return _requestProcessor;
-		}
+        public IRequestProcessor GetRequestProcessor()
+        {
+            return _requestProcessor;
+        }
 
-		public void Dispose()
-		{
-			if (_scheduler != null)
-			{
-				_scheduler.Stop();
-				_scheduler.Dispose();
-			}
-			if (_disposableServer != null)
-			{
-				_disposableServer.Dispose();
-			}
-		}
+        public void Dispose()
+        {
+            if (_scheduler != null)
+            {
+                _scheduler.Stop();
+                _scheduler.Dispose();
+            }
+            if (_disposableServer != null)
+            {
+                _disposableServer.Dispose();
+            }
+        }
 
-		public IRequestStub Stub(Func<RequestHandlerFactory, IRequestStub> func)
-		{
-			return func.Invoke(_requestHandlerFactory);
-		}
+        public IRequestStub Stub(Func<RequestHandlerFactory, IRequestStub> func)
+        {
+            return func.Invoke(_requestHandlerFactory);
+        }
 
-		public IHttpServer WithNewContext()
-		{
-			_requestProcessor.ClearHandlers();
-			return this;
-		}
+        public IHttpServer WithNewContext(Guid sessionId)
+        {
+            _requestProcessor.ClearHandlers(sessionId);
+            return this;
+        }
 
-		public string WhatDoIHave()
-		{
-			return _requestProcessor.WhatDoIHave();
-		}
+        public string WhatDoIHave()
+        {
+            return _requestProcessor.WhatDoIHave();
+        }
 
-		private void StartListening()
-		{
-			try
-			{
-				var ipEndPoint = new IPEndPoint(IPAddress.Any, _uri.Port);
-				Exception e = null;
-				_scheduler.Post(() =>
-				{
-					try
-					{
-						_disposableServer = KayakServer.Factory
-							.CreateHttp(_requestProcessor, _scheduler)
-							.Listen(ipEndPoint);
-					}
-					catch (Exception ex)
-					{
-						e = ex;
-						_log.Error("Error when trying to post actions to the scheduler in StartListening", ex);
-					}
-				});
+        private void StartListening()
+        {
+            try
+            {
+                var ipEndPoint = new IPEndPoint(IPAddress.Any, _uri.Port);
+                Exception e = null;
+                _scheduler.Post(() =>
+                {
+                    try
+                    {
+                        _disposableServer = KayakServer.Factory
+                            .CreateHttp(_requestProcessor, _scheduler)
+                            .Listen(ipEndPoint);
+                    }
+                    catch (Exception ex)
+                    {
+                        e = ex;
+                        _log.Error("Error when trying to post actions to the scheduler in StartListening", ex);
+                    }
+                });
 
-				_scheduler.Start();
-				Thread.Sleep(100);
-				if (e != null)
-					throw e;
-			}
-			catch (Exception ex)
-			{
-				_log.Error("Error when trying to StartListening", ex);
-			}
-		}
-	}
+                _scheduler.Start();
+                Thread.Sleep(100);
+                if (e != null)
+                    throw e;
+            }
+            catch (Exception ex)
+            {
+                _log.Error("Error when trying to StartListening", ex);
+            }
+        }
+    }
 }

--- a/src/HttpMock/IHttpServer.cs
+++ b/src/HttpMock/IHttpServer.cs
@@ -5,7 +5,7 @@ namespace HttpMock
 	public interface IHttpServer : IDisposable
 	{
 		IRequestStub Stub(Func<RequestHandlerFactory, IRequestStub> func);
-		IHttpServer WithNewContext();
+		IHttpServer WithNewContext(Guid sessionId=default(Guid));
 		void Start();
 		string WhatDoIHave();
 		bool IsAvailable();

--- a/src/HttpMock/IRequestProcessor.cs
+++ b/src/HttpMock/IRequestProcessor.cs
@@ -1,12 +1,13 @@
 ﻿using Kayak.Http;
+using System;
 
 namespace HttpMock
 {
-	public interface IRequestProcessor : IHttpRequestDelegate
-	{
-		IRequestVerify FindHandler(string method, string path);
-		void Add(RequestHandler requestHandler);
-		void ClearHandlers();
-		string WhatDoIHave();
-	}
+    public interface IRequestProcessor : IHttpRequestDelegate
+    {
+        IRequestVerify FindHandler(string method, string path, Guid sessionId=default(Guid));
+        void Add(RequestHandler requestHandler);
+        void ClearHandlers(Guid sessionId);
+        string WhatDoIHave();
+    }
 }

--- a/src/HttpMock/RequestProcessor.cs
+++ b/src/HttpMock/RequestProcessor.cs
@@ -41,7 +41,8 @@ namespace HttpMock
                 var mockSessionId = request.Headers[Constants.CookieHeaderKey].Split("=".ToCharArray());
                 currentRequestId = new Guid(mockSessionId[1]);
             }
-            if (_handlers.TryGetValue(currentRequestId, out var requestHandler))
+            RequestHandlerList requestHandler;
+            if (_handlers.TryGetValue(currentRequestId, out requestHandler))
             {
                 lock (requestHandler)
                 {
@@ -94,7 +95,8 @@ namespace HttpMock
         }
 
         public IRequestVerify FindHandler(string method, string path, Guid sessionId = default(Guid)) {
-            if (_handlers.TryGetValue(sessionId, out var finder))
+            RequestHandlerList finder;
+            if (_handlers.TryGetValue(sessionId, out finder))
             {
                 return (IRequestVerify)finder.FirstOrDefault(x => x.Path == path && x.Method == method);
             }
@@ -123,7 +125,8 @@ namespace HttpMock
         }
 
         public void ClearHandlers(Guid sessionId) {
-            _handlers.TryRemove(sessionId, out var lst);
+            RequestHandlerList lst;
+            _handlers.TryRemove(sessionId, out lst);
         }
 
         public void Add(RequestHandler requestHandler) {
@@ -137,7 +140,8 @@ namespace HttpMock
                 var mockSessionId = requestHandler.RequestHeaders[Constants.CookieHeaderKey].Split("=".ToCharArray());
                 currentRequestId = new Guid(mockSessionId[1]);
             }
-            if (_handlers.TryGetValue(currentRequestId, out var lst))
+            RequestHandlerList lst;
+            if (_handlers.TryGetValue(currentRequestId, out lst))
             {
                 lock (lst)
                 {

--- a/src/HttpMock/RequestProcessor.cs
+++ b/src/HttpMock/RequestProcessor.cs
@@ -15,14 +15,17 @@ namespace HttpMock
         private ConcurrentDictionary<Guid, RequestHandlerList> _handlers { get; set; }
         private readonly RequestMatcher _requestMatcher;
 
-        public RequestProcessor(IMatchingRule matchingRule, ConcurrentDictionary<Guid, RequestHandlerList> requestHandlers) {
+        public RequestProcessor(IMatchingRule matchingRule, ConcurrentDictionary<Guid, RequestHandlerList> requestHandlers)
+        {
             _handlers = requestHandlers;
             _requestMatcher = new RequestMatcher(matchingRule);
         }
 
-        public void OnRequest(HttpRequestHead request, IDataProducer body, IHttpResponseDelegate response) {
+        public void OnRequest(HttpRequestHead request, IDataProducer body, IHttpResponseDelegate response)
+        {
             _log.DebugFormat("Start Processing request for : {0}:{1}", request.Method, request.Uri);
-            if (GetHandlerCount() < 1) {
+            if (GetHandlerCount() < 1)
+            {
                 ReturnHttpMockNotFound(response);
                 return;
             }
@@ -36,7 +39,7 @@ namespace HttpMock
             {
                 currentRequestId = new Guid(request.Headers[Constants.MockSessionHeaderKey]);
             }
-            else if (request.Headers.ContainsKey(Constants.CookieHeaderKey))
+            else if (request.Headers.ContainsKey(Constants.CookieHeaderKey) && request.Headers[Constants.CookieHeaderKey].Contains("="))
             {
                 var mockSessionId = request.Headers[Constants.CookieHeaderKey].Split("=".ToCharArray());
                 currentRequestId = new Guid(mockSessionId[1]);
@@ -59,7 +62,8 @@ namespace HttpMock
             HandleRequest(request, body, response, handler);
         }
 
-        private static void HandleRequest(HttpRequestHead request, IDataProducer body, IHttpResponseDelegate response, IRequestHandler handler) {
+        private static void HandleRequest(HttpRequestHead request, IDataProducer body, IHttpResponseDelegate response, IRequestHandler handler)
+        {
             _log.DebugFormat("Matched a handler {0}:{1} {2}", handler.Method, handler.Path, DumpQueryParams(handler.QueryParams));
             IDataProducer dataProducer = GetDataProducer(request, handler);
             if (request.HasBody())
@@ -86,15 +90,18 @@ namespace HttpMock
             _log.DebugFormat("End Processing request for : {0}:{1}", request.Method, request.Uri);
         }
 
-        private static IDataProducer GetDataProducer(HttpRequestHead request, IRequestHandler handler) {
+        private static IDataProducer GetDataProducer(HttpRequestHead request, IRequestHandler handler)
+        {
             return request.Method != "HEAD" ? handler.ResponseBuilder.BuildBody(request.Headers) : null;
         }
 
-        private int GetHandlerCount() {
+        private int GetHandlerCount()
+        {
             return _handlers.Count();
         }
 
-        public IRequestVerify FindHandler(string method, string path, Guid sessionId = default(Guid)) {
+        public IRequestVerify FindHandler(string method, string path, Guid sessionId = default(Guid))
+        {
             RequestHandlerList finder;
             if (_handlers.TryGetValue(sessionId, out finder))
             {
@@ -103,7 +110,8 @@ namespace HttpMock
             return null;
         }
 
-        private static string DumpQueryParams(IDictionary<string, string> queryParams) {
+        private static string DumpQueryParams(IDictionary<string, string> queryParams)
+        {
             var sb = new StringBuilder();
             foreach (var param in queryParams)
             {
@@ -112,7 +120,8 @@ namespace HttpMock
             return sb.ToString();
         }
 
-        private static void ReturnHttpMockNotFound(IHttpResponseDelegate response) {
+        private static void ReturnHttpMockNotFound(IHttpResponseDelegate response)
+        {
             var dictionary = new Dictionary<string, string>
             {
                 {HttpHeaderNames.ContentLength, "0"},
@@ -124,12 +133,14 @@ namespace HttpMock
             response.OnResponse(notFoundResponse, null);
         }
 
-        public void ClearHandlers(Guid sessionId) {
+        public void ClearHandlers(Guid sessionId)
+        {
             RequestHandlerList lst;
             _handlers.TryRemove(sessionId, out lst);
         }
 
-        public void Add(RequestHandler requestHandler) {
+        public void Add(RequestHandler requestHandler)
+        {
             Guid currentRequestId = Guid.Empty;
             if (requestHandler.RequestHeaders.ContainsKey(Constants.MockSessionHeaderKey))
             {
@@ -156,7 +167,8 @@ namespace HttpMock
             }
         }
 
-        public string WhatDoIHave() {
+        public string WhatDoIHave()
+        {
             var stringBuilder = new StringBuilder();
             stringBuilder.AppendLine("Handlers:");
             foreach (var requestHandler in _handlers)

--- a/src/HttpMock/RequestProcessor.cs
+++ b/src/HttpMock/RequestProcessor.cs
@@ -5,112 +5,164 @@ using System.Reflection;
 using System.Text;
 using Kayak;
 using Kayak.Http;
+using System.Collections.Concurrent;
 
 namespace HttpMock
 {
-	public class RequestProcessor :  IRequestProcessor
-	{
-		private static readonly ILog _log = LogFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-	    private IRequestHandlerList _handlers;
-	    private readonly RequestMatcher _requestMatcher;
+    public class RequestProcessor : IRequestProcessor
+    {
+        private static readonly ILog _log = LogFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private ConcurrentDictionary<Guid, RequestHandlerList> _handlers { get; set; }
+        private readonly RequestMatcher _requestMatcher;
 
-	    public RequestProcessor(IMatchingRule matchingRule, IRequestHandlerList requestHandlers) {
-	        _handlers = requestHandlers;
-		    _requestMatcher = new RequestMatcher(matchingRule);
-		}
+        public RequestProcessor(IMatchingRule matchingRule, ConcurrentDictionary<Guid, RequestHandlerList> requestHandlers) {
+            _handlers = requestHandlers;
+            _requestMatcher = new RequestMatcher(matchingRule);
+        }
 
-		public void OnRequest(HttpRequestHead request, IDataProducer body, IHttpResponseDelegate response) {
-			_log.DebugFormat("Start Processing request for : {0}:{1}", request.Method, request.Uri);
-			if (GetHandlerCount() < 1) {
-				ReturnHttpMockNotFound(response);
-				return;
-			}
+        public void OnRequest(HttpRequestHead request, IDataProducer body, IHttpResponseDelegate response) {
+            _log.DebugFormat("Start Processing request for : {0}:{1}", request.Method, request.Uri);
+            if (GetHandlerCount() < 1) {
+                ReturnHttpMockNotFound(response);
+                return;
+            }
+            IRequestHandler handler = null;
+            Guid currentRequestId = Guid.Empty;
+            if (request.Headers == null)
+            {
+                _log.DebugFormat("No header specified");
+            }
+            else if (request.Headers.ContainsKey(Constants.MockSessionHeaderKey))
+            {
+                currentRequestId = new Guid(request.Headers[Constants.MockSessionHeaderKey]);
+            }
+            else if (request.Headers.ContainsKey(Constants.CookieHeaderKey))
+            {
+                var mockSessionId = request.Headers[Constants.CookieHeaderKey].Split("=".ToCharArray());
+                currentRequestId = new Guid(mockSessionId[1]);
+            }
+            if (_handlers.TryGetValue(currentRequestId, out var requestHandler))
+            {
+                lock (requestHandler)
+                {
 
-			var handler = _requestMatcher.Match(request, _handlers);
+                    handler = _requestMatcher.Match(request, requestHandler);
+                }
+            }
+            if (handler == null)
+            {
+                _log.DebugFormat("No Handlers matched");
+                ReturnHttpMockNotFound(response);
+                return;
+            }
+            HandleRequest(request, body, response, handler);
+        }
 
-			if (handler == null) {
-				_log.DebugFormat("No Handlers matched");
-				ReturnHttpMockNotFound(response);
-				return;
-			}
-			HandleRequest(request, body, response, handler);
-		}
+        private static void HandleRequest(HttpRequestHead request, IDataProducer body, IHttpResponseDelegate response, IRequestHandler handler) {
+            _log.DebugFormat("Matched a handler {0}:{1} {2}", handler.Method, handler.Path, DumpQueryParams(handler.QueryParams));
+            IDataProducer dataProducer = GetDataProducer(request, handler);
+            if (request.HasBody())
+            {
+                body.Connect(new BufferedConsumer(
+                    bufferedBody =>
+                    {
+                        handler.RecordRequest(request, bufferedBody);
+                        _log.DebugFormat("Body: {0}", bufferedBody);
+                        response.OnResponse(handler.ResponseBuilder.BuildHeaders(), dataProducer);
+                    },
+                    error =>
+                    {
+                        _log.DebugFormat("Error while reading body {0}", error.Message);
+                        response.OnResponse(handler.ResponseBuilder.BuildHeaders(), dataProducer);
+                    }
+                    ));
+            }
+            else
+            {
+                response.OnResponse(handler.ResponseBuilder.BuildHeaders(), dataProducer);
+                handler.RecordRequest(request, null);
+            }
+            _log.DebugFormat("End Processing request for : {0}:{1}", request.Method, request.Uri);
+        }
 
-	    private static void HandleRequest(HttpRequestHead request, IDataProducer body, IHttpResponseDelegate response, IRequestHandler handler)
-	    {
-	        _log.DebugFormat("Matched a handler {0}:{1} {2}", handler.Method, handler.Path, DumpQueryParams(handler.QueryParams));
-	        IDataProducer dataProducer = GetDataProducer(request, handler);
-	        if (request.HasBody())
-	        {
-	            body.Connect(new BufferedConsumer(
-	                bufferedBody =>
-	                {
-	                    handler.RecordRequest(request, bufferedBody);
-	                    _log.DebugFormat("Body: {0}", bufferedBody);
-	                    response.OnResponse(handler.ResponseBuilder.BuildHeaders(), dataProducer);
-	                },
-	                error =>
-	                {
-	                    _log.DebugFormat("Error while reading body {0}", error.Message);
-	                    response.OnResponse(handler.ResponseBuilder.BuildHeaders(), dataProducer);
-	                }
-	                ));
-	        }
-	        else
-	        {
-	            response.OnResponse(handler.ResponseBuilder.BuildHeaders(), dataProducer);
-	            handler.RecordRequest(request, null);
-	        }
-	        _log.DebugFormat("End Processing request for : {0}:{1}", request.Method, request.Uri);
-	    }
+        private static IDataProducer GetDataProducer(HttpRequestHead request, IRequestHandler handler) {
+            return request.Method != "HEAD" ? handler.ResponseBuilder.BuildBody(request.Headers) : null;
+        }
 
-	    private static IDataProducer GetDataProducer(HttpRequestHead request, IRequestHandler handler) {
-			return request.Method != "HEAD" ? handler.ResponseBuilder.BuildBody(request.Headers) : null;
-		}
+        private int GetHandlerCount() {
+            return _handlers.Count();
+        }
 
-		private int GetHandlerCount() {
-			return _handlers.Count();
-		}
+        public IRequestVerify FindHandler(string method, string path, Guid sessionId = default(Guid)) {
+            if (_handlers.TryGetValue(sessionId, out var finder))
+            {
+                return (IRequestVerify)finder.FirstOrDefault(x => x.Path == path && x.Method == method);
+            }
+            return null;
+        }
 
-	    public IRequestVerify FindHandler(string method, string path) {
-			return (IRequestVerify) _handlers.Where(x => x.Path == path && x.Method == method).FirstOrDefault();
-		}
+        private static string DumpQueryParams(IDictionary<string, string> queryParams) {
+            var sb = new StringBuilder();
+            foreach (var param in queryParams)
+            {
+                sb.AppendFormat("{0}={1}&", param.Key, param.Value);
+            }
+            return sb.ToString();
+        }
 
-		private static string DumpQueryParams(IDictionary<string, string> queryParams) {
-			var sb = new StringBuilder();
-			foreach (var param in queryParams) {
-				sb.AppendFormat("{0}={1}&", param.Key, param.Value);
-			}
-			return sb.ToString();
-		}
+        private static void ReturnHttpMockNotFound(IHttpResponseDelegate response) {
+            var dictionary = new Dictionary<string, string>
+            {
+                {HttpHeaderNames.ContentLength, "0"},
+                {"X-HttpMockError", "No handler found to handle request"}
+            };
 
-		private static void ReturnHttpMockNotFound(IHttpResponseDelegate response) {
-			var dictionary = new Dictionary<string, string>
-			{
-				{HttpHeaderNames.ContentLength, "0"},
-				{"X-HttpMockError", "No handler found to handle request"}
-			};
+            var notFoundResponse = new HttpResponseHead
+            { Status = string.Format("{0} {1}", 404, "NotFound"), Headers = dictionary };
+            response.OnResponse(notFoundResponse, null);
+        }
 
-			var notFoundResponse = new HttpResponseHead
-			{Status = string.Format("{0} {1}", 404, "NotFound"), Headers = dictionary};
-			response.OnResponse(notFoundResponse, null);
-		}
+        public void ClearHandlers(Guid sessionId) {
+            _handlers.TryRemove(sessionId, out var lst);
+        }
 
-		public void ClearHandlers() {
-			_handlers = new RequestHandlerList();
-		}
+        public void Add(RequestHandler requestHandler) {
+            Guid currentRequestId = Guid.Empty;
+            if (requestHandler.RequestHeaders.ContainsKey(Constants.MockSessionHeaderKey))
+            {
+                currentRequestId = new Guid(requestHandler.RequestHeaders[Constants.MockSessionHeaderKey]);
+            }
+            else if (requestHandler.RequestHeaders.ContainsKey(Constants.CookieHeaderKey))
+            {
+                var mockSessionId = requestHandler.RequestHeaders[Constants.CookieHeaderKey].Split("=".ToCharArray());
+                currentRequestId = new Guid(mockSessionId[1]);
+            }
+            if (_handlers.TryGetValue(currentRequestId, out var lst))
+            {
+                lock (lst)
+                {
+                    lst.Add(requestHandler);
+                    _handlers.TryUpdate(currentRequestId, lst, _handlers[currentRequestId]);
+                }
+            }
+            else
+            {
+                lst = new RequestHandlerList { requestHandler };
+                _handlers.TryAdd(currentRequestId, lst);
+            }
+        }
 
-		public void Add(RequestHandler requestHandler) {
-			_handlers.Add(requestHandler);
-		}
-
-		public string WhatDoIHave() {
-			var stringBuilder = new StringBuilder();
-			stringBuilder.AppendLine("Handlers:");
-			foreach (RequestHandler handler in _handlers) {
-				stringBuilder.Append(handler.ToString());
-			}
-			return stringBuilder.ToString();
-		}
-	}
+        public string WhatDoIHave() {
+            var stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine("Handlers:");
+            foreach (var requestHandler in _handlers)
+            {
+                foreach (RequestHandler handler in requestHandler.Value)
+                {
+                    stringBuilder.Append(handler.ToString());
+                }
+            }
+            return stringBuilder.ToString();
+        }
+    }
 }


### PR DESCRIPTION
I was assign one work to optimize the build process which was taking around 2 hours to complete. So i made changes to the code base to run the scenarios in parallel. In this due process i made changes to HttpMock repo to support session and concurrency. Now with these changes it brings down the test running time to 30 minutes.

With the current changes now httpmock will support:
1. Concurrency.
2. Session.
3. Private/Shared Mocks (in the context of initializing a single HttpMock server with parallel running scenarios )
4. WithNewContext support to individual scenarios. (Which will not break already running scenarios in parallel)

Thanks!