### PR TITLE
#92 Fixed a bug in URLs containing regular expression reserved characters

### DIFF
--- a/src/HttpMock.Unit.Tests/EndpointMatchingRuleTests.cs
+++ b/src/HttpMock.Unit.Tests/EndpointMatchingRuleTests.cs
@@ -226,8 +226,18 @@ namespace HttpMock.Unit.Tests
 			
 		}
 
+        [Test]
+        public void should_match_urls_containings_regex_reserved_characters()
+        {
+            var requestHandler = MockRepository.GenerateStub<IRequestHandler>();
+            requestHandler.Path = "/test()";
+            requestHandler.QueryParams = new Dictionary<string, string>();
 
-	}
+            var httpRequestHead = new HttpRequestHead { Uri = "/test()" };
+            var endpointMatchingRule = new EndpointMatchingRule();
+            Assert.That(endpointMatchingRule.IsEndpointMatch(requestHandler, httpRequestHead));
+        }
+    }
 
 
     [TestFixture]

--- a/src/HttpMock/EndpointMatchingRule.cs
+++ b/src/HttpMock/EndpointMatchingRule.cs
@@ -56,7 +56,7 @@ namespace HttpMock
 	        {
 	            pathToMatch = request.Uri.Substring(0, positionOfQueryStart);
 	        }
-            var pathMatch = new Regex(string.Format(@"^{0}\/*$", requestHandler.Path));
+            var pathMatch = new Regex(string.Format(@"^{0}\/*$", Regex.Escape(requestHandler.Path)));
 	        return pathMatch.IsMatch(pathToMatch);
 	    }
 


### PR DESCRIPTION
Fixed a bug that caused URLs containing regular expression reserved characters to fail the URL matching. Added unit test for the fixed feature.