### PR TITLE
Requesthandler.LastRequest does not return the last request

### DIFF
--- a/src/HttpMock.Integration.Tests/HttpEndPointTests.cs
+++ b/src/HttpMock.Integration.Tests/HttpEndPointTests.cs
@@ -80,6 +80,30 @@ namespace HttpMock.Integration.Tests
 
 			Assert.That(requestBody, Is.EqualTo(expected));
 		}
+		
+		[Test]
+		public void Should_get_the_last_request_that_was_sent()
+		{
+			
+			var expected = "expectedbody";
+			_stubHttp = HttpMockRepository.At(_hostUrl);
+			var requestHandler =_stubHttp.Stub( x => x.Post("/endpoint"));
+			requestHandler.Return(expected).OK();
+			
+			using (var wc = new WebClient())
+			{
+				wc.Headers[HttpRequestHeader.ContentType] = "application/xml";
+				wc.UploadString(string.Format("{0}/endpoint", _hostUrl), "first");
+				wc.UploadString(string.Format("{0}/endpoint", _hostUrl), "second");
+				
+				wc.UploadString(string.Format("{0}/endpoint", _hostUrl), expected);
+			}
+			
+
+			var requestBody = ((RequestHandler) requestHandler).LastRequest().Body;
+			
+			Assert.That(requestBody, Is.EqualTo(expected));
+		}
 
 
 		[Test]

--- a/src/HttpMock.Integration.Tests/HttpEndPointTests.cs
+++ b/src/HttpMock.Integration.Tests/HttpEndPointTests.cs
@@ -34,7 +34,6 @@ namespace HttpMock.Integration.Tests
 				.OK();
 
 
-
 			string result = new WebClient().DownloadString(string.Format("{0}/endpoint", _hostUrl));
 
 			Assert.That(result, Is.EqualTo(expected));
@@ -45,7 +44,9 @@ namespace HttpMock.Integration.Tests
 		{
 			_stubHttp = HttpMockRepository.At(_hostUrl);
 
-			byte[] expected = Encoding.UTF8.GetBytes("<xml><>response>Change to bytes to simulate possible stream response</response></xml>");
+			byte[] expected =
+				Encoding.UTF8.GetBytes(
+					"<xml><>response>Change to bytes to simulate possible stream response</response></xml>");
 			_stubHttp.Stub(x => x.Get("/endpoint"))
 				.Return(expected)
 				.OK();
@@ -55,29 +56,30 @@ namespace HttpMock.Integration.Tests
 			Assert.That(result, Is.EqualTo(expected));
 		}
 
-        [TestCase(1)]
-        [TestCase(100)]
-        [TestCase(5000)]
-        public void SUT_should_get_back_exact_content_in_the_last_request_body(int count)
-        {
-            _stubHttp = HttpMockRepository.At(_hostUrl);
+		[TestCase(1)]
+		[TestCase(100)]
+		[TestCase(5000)]
+		public void SUT_should_get_back_exact_content_in_the_last_request_body(int count)
+		{
+			_stubHttp = HttpMockRepository.At(_hostUrl);
 
-            string expected = string.Format("<xml><>response>{0}</response></xml>", string.Join(" ", Enumerable.Range(0, count)));
-            var requestHandler = _stubHttp.Stub(x => x.Post("/endpoint"));
+			string expected = string.Format("<xml><>response>{0}</response></xml>",
+				string.Join(" ", Enumerable.Range(0, count)));
+			var requestHandler = _stubHttp.Stub(x => x.Post("/endpoint"));
 
-            requestHandler.Return(expected).OK();
+			requestHandler.Return(expected).OK();
 
-            
 
-            using (var wc = new WebClient())
-            {
-                wc.Headers[HttpRequestHeader.ContentType] = "application/xml";
-                wc.UploadString(string.Format("{0}/endpoint", _hostUrl), expected);
-            }
-            var requestBody = ((RequestHandler)requestHandler).LastRequest().Body;
+			using (var wc = new WebClient())
+			{
+				wc.Headers[HttpRequestHeader.ContentType] = "application/xml";
+				wc.UploadString(string.Format("{0}/endpoint", _hostUrl), expected);
+			}
 
-            Assert.That(requestBody, Is.EqualTo(expected));
-        }      
+			var requestBody = ((RequestHandler) requestHandler).LastRequest().Body;
+
+			Assert.That(requestBody, Is.EqualTo(expected));
+		}
 
 
 		[Test]
@@ -126,7 +128,6 @@ namespace HttpMock.Integration.Tests
 				.WithStatus(HttpStatusCode.Unauthorized);
 
 
-
 			var wc = new WebClient();
 
 			Assert.That(wc.DownloadString(string.Format("{0}/api2/status", _hostUrl)), Is.EqualTo("Hello"));
@@ -137,7 +138,7 @@ namespace HttpMock.Integration.Tests
 			}
 			catch (Exception ex)
 			{
-				Assert.That(ex, Is.InstanceOf(typeof (WebException)));
+				Assert.That(ex, Is.InstanceOf(typeof(WebException)));
 				Assert.That(((WebException) ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
 			}
 
@@ -147,7 +148,7 @@ namespace HttpMock.Integration.Tests
 			}
 			catch (Exception ex)
 			{
-				Assert.That(ex, Is.InstanceOf(typeof (WebException)));
+				Assert.That(ex, Is.InstanceOf(typeof(WebException)));
 				Assert.That(((WebException) ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
 			}
 		}
@@ -171,7 +172,6 @@ namespace HttpMock.Integration.Tests
 				.WithStatus(HttpStatusCode.Unauthorized);
 
 
-
 			for (int count = 0; count < 6; count++)
 			{
 				RequestEcho(endpoint);
@@ -193,7 +193,6 @@ namespace HttpMock.Integration.Tests
 					.WithStatus(HttpStatusCode.PartialContent);
 
 
-
 				HttpWebRequest request = (HttpWebRequest) HttpWebRequest.Create(_hostUrl + query);
 				request.Method = "GET";
 				request.AddRange(0, 1023);
@@ -203,6 +202,7 @@ namespace HttpMock.Integration.Tests
 				{
 					response.GetResponseStream().Read(downloadData, 0, downloadData.Length);
 				}
+
 				Assert.That(downloadData.Length, Is.EqualTo(1024));
 			}
 			finally
@@ -228,7 +228,6 @@ namespace HttpMock.Integration.Tests
 				.OK();
 
 
-
 			var request = (HttpWebRequest) WebRequest.Create(string.Format("{0}/endpoint", _hostUrl));
 			request.Method = "PURGE";
 			request.Host = "nonstandard.host";
@@ -241,6 +240,118 @@ namespace HttpMock.Integration.Tests
 			}
 		}
 
+		[TestCase(1)]
+		[TestCase(10)]
+		[TestCase(50)]
+		public void SUT_should_get_back_the_collection_of_requests(int count)
+		{
+			_stubHttp = HttpMockRepository.At(_hostUrl);
+
+			var requestHandlerStub = _stubHttp.Stub(x => x.Post("/endpoint"));
+
+			requestHandlerStub.Return(string.Empty).OK();
+
+			var expectedBodyList = new List<string>();
+			using (var wc = new WebClient())
+			{
+				wc.Headers[HttpRequestHeader.ContentType] = "application/xml";
+				for (int i = 0; i < count; i++)
+				{
+					string expected = string.Format("<xml><>response>{0}</response></xml>",
+						string.Join(" ", Enumerable.Range(0, i)));
+					wc.UploadString(string.Format("{0}/endpoint", _hostUrl), expected);
+					expectedBodyList.Add(expected);
+				}
+			}
+
+			var requestHandler = (RequestHandler) requestHandlerStub;
+
+			var observedRequests = requestHandler.GetObservedRequests();
+			Assert.AreEqual(expectedBodyList.Count, observedRequests.ToList().Count);
+
+			for (int i = 0; i < expectedBodyList.Count; i++)
+			{
+				Assert.AreEqual(expectedBodyList.ElementAt(i), observedRequests.ElementAt(i).Body);
+			}
+		}
+
+		[TestCase(500, 200)]
+		[TestCase(1234, 250)]
+		[TestCase(2000, 350)]
+		public void Should_wait_more_than_the_added_delay(int wait, int added)
+		{
+			_stubHttp = HttpMockRepository.At(_hostUrl);
+			var stub = _stubHttp.Stub(x => x.Get("/endpoint")).Return("Delayed response");
+			stub.OK();
+
+			stub.WithDelay(wait);
+			string ans;
+			var sw = new Stopwatch();
+
+			using (var wc = new WebClient())
+			{
+				sw.Start();
+				ans = wc.DownloadString($"{_hostUrl}/endpoint");
+				sw.Stop();
+			}
+
+			Assert.GreaterOrEqual(sw.ElapsedMilliseconds, wait);
+			Assert.AreEqual("Delayed response", ans);
+
+			stub.WithDelay(TimeSpan.FromMilliseconds(added)).Return("Delayed response 2");
+			sw.Reset();
+			using (var wc = new WebClient())
+			{
+				sw.Start();
+				ans = wc.DownloadString($"{_hostUrl}/endpoint");
+				sw.Stop();
+			}
+
+			Assert.GreaterOrEqual(sw.ElapsedMilliseconds, wait + added);
+			Assert.AreEqual("Delayed response 2", ans);
+		}
+
+		[TestCase(407, 50)]
+		[TestCase(1015, 50)]
+		[TestCase(1691, 50)]
+		public void Delayed_stub_shouldnt_block_undelayed_stub(int wait, int epsilon)
+		{
+			_stubHttp = HttpMockRepository.At(_hostUrl);
+			_stubHttp.Stub(x => x.Get("/firstEndp")).WithDelay(wait).Return("Delayed response (stub 1)").OK();
+			_stubHttp.Stub(x => x.Get("/secondEndp")).Return("Undelayed response (stub 2)").OK();
+
+			Stopwatch swDelayed = new Stopwatch();
+			Stopwatch swUndelayed = new Stopwatch();
+			Task<string> taskDelayed = null,
+				taskUndelayed = null;
+
+			using (var wcUndelayed = new WebClient())
+			using (var wcDelayed = new WebClient())
+			{
+				// This triggers the server so that we won't have any initial (unwanted) delays
+
+				wcDelayed.DownloadString($"{_hostUrl}/firstEndp");
+				wcUndelayed.DownloadString($"{_hostUrl}/secondEndp");
+
+				taskDelayed = StartDelayedRequest(swDelayed);
+
+				taskUndelayed = Task.Run(() =>
+				{
+					swUndelayed.Start();
+					var ans = wcUndelayed.DownloadString($"{_hostUrl}/secondEndp");
+					swUndelayed.Stop();
+					return ans;
+				});
+
+				taskDelayed.Wait();
+				taskUndelayed.Wait();
+			}
+
+			Assert.AreEqual("Delayed response (stub 1)", taskDelayed.Result);
+			Assert.AreEqual("Undelayed response (stub 2)", taskUndelayed.Result);
+			Assert.Greater(swDelayed.ElapsedMilliseconds - epsilon, swUndelayed.ElapsedMilliseconds);
+		}
+
 		private string CreateFile(int fileSize)
 		{
 			string fileName = Path.GetTempFileName();
@@ -250,8 +361,10 @@ namespace HttpMock.Integration.Tests
 				{
 					fileStream.WriteByte((byte) count);
 				}
+
 				fileStream.Close();
 			}
+
 			return fileName;
 		}
 
@@ -265,136 +378,21 @@ namespace HttpMock.Integration.Tests
 			}
 			catch (Exception ex)
 			{
-				Assert.That(ex, Is.InstanceOf(typeof (WebException)));
+				Assert.That(ex, Is.InstanceOf(typeof(WebException)));
 				Assert.That(((WebException) ex).Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
 			}
 		}
-		
-		[TestCase(1)]
-        [TestCase(10)]
-        [TestCase(50)]
-        public void SUT_should_get_back_the_collection_of_requests(int count)
-        {
-            _stubHttp = HttpMockRepository.At(_hostUrl);
-
-            var requestHandlerStub = _stubHttp.Stub(x => x.Post("/endpoint"));
-
-            requestHandlerStub.Return(string.Empty).OK();
-
-            var expectedBodyList = new List<string>();
-            using (var wc = new WebClient())
-            {
-                wc.Headers[HttpRequestHeader.ContentType] = "application/xml";
-                for (int i = 0; i < count; i++)
-                {
-                    string expected = string.Format("<xml><>response>{0}</response></xml>", string.Join(" ", Enumerable.Range(0, i)));
-                    wc.UploadString(string.Format("{0}/endpoint", _hostUrl), expected);
-                    expectedBodyList.Add(expected);
-                }
-            }
-
-            var requestHandler = (RequestHandler)requestHandlerStub;
-
-            var observedRequests = requestHandler.GetObservedRequests();
-            Assert.AreEqual(expectedBodyList.Count, observedRequests.ToList().Count);
-
-            for (int i = 0; i < expectedBodyList.Count; i++)
-            {
-                Assert.AreEqual(expectedBodyList.ElementAt(i), observedRequests.ElementAt(i).Body);
-            }
-        }
-
-        [TestCase(500, 200)]
-        [TestCase(1234, 250)]
-        [TestCase(2000, 350)]
-        public void Should_wait_more_than_the_added_delay(int wait, int added)
-        {
-            _stubHttp = HttpMockRepository.At(_hostUrl);
-            var stub = _stubHttp.Stub(x => x.Get("/endpoint")).Return("Delayed response");
-            stub.OK();
-
-            stub.WithDelay(wait);
-            string ans;
-            var sw = new Stopwatch();
-
-            using (var wc = new WebClient())
-            {
-                sw.Start();
-                ans = wc.DownloadString($"{_hostUrl}/endpoint");
-                sw.Stop();
-            }
-
-            Assert.GreaterOrEqual(sw.ElapsedMilliseconds, wait);
-            Assert.AreEqual("Delayed response", ans);
-
-            stub.WithDelay(TimeSpan.FromMilliseconds(added)).Return("Delayed response 2");
-            sw.Reset();
-            using (var wc = new WebClient())
-            {
-                sw.Start();
-                ans = wc.DownloadString($"{_hostUrl}/endpoint");
-                sw.Stop();
-            }
-
-            Assert.GreaterOrEqual(sw.ElapsedMilliseconds, wait + added);
-            Assert.AreEqual("Delayed response 2", ans);
-
-        }
 
 
-        public async Task<string> StartDelayedRequest(Stopwatch sw)
-        {
-            using (var wc = new WebClient())
-            {
-                sw.Restart();
-                var ans = await wc.DownloadStringTaskAsync($"{_hostUrl}/firstEndp");
-                sw.Stop();
-                return ans;
-            }
-        }
-
-        [TestCase(407, 50)]
-        [TestCase(1015, 50)]
-        [TestCase(1691, 50)]
-        public void Delayed_stub_shouldnt_block_undelayed_stub(int wait, int epsilon)
-        {
-            _stubHttp = HttpMockRepository.At(_hostUrl);
-            _stubHttp.Stub(x => x.Get("/firstEndp")).WithDelay(wait).Return("Delayed response (stub 1)").OK();
-            _stubHttp.Stub(x => x.Get("/secondEndp")).Return("Undelayed response (stub 2)").OK();
-
-            Stopwatch swDelayed = new Stopwatch();
-            Stopwatch swUndelayed = new Stopwatch();
-            Task<string> taskDelayed = null, 
-                taskUndelayed = null;
-
-            using (var wcUndelayed = new WebClient())
-            using (var wcDelayed = new WebClient())
-            {
-
-                // This triggers the server so that we won't have any initial (unwanted) delays
-	        
-                wcDelayed.DownloadString($"{_hostUrl}/firstEndp");
-	            wcUndelayed.DownloadString($"{_hostUrl}/secondEndp");
-
-                taskDelayed = StartDelayedRequest(swDelayed);
-
-                taskUndelayed = Task.Run(() =>
-                {
-                    swUndelayed.Start();
-                    var ans = wcUndelayed.DownloadString($"{_hostUrl}/secondEndp");
-                    swUndelayed.Stop();
-                    return ans;
-                });
-
-                taskDelayed.Wait();
-                taskUndelayed.Wait();
-            }
-
-            Assert.AreEqual("Delayed response (stub 1)", taskDelayed.Result);
-            Assert.AreEqual("Undelayed response (stub 2)", taskUndelayed.Result);
-            Assert.Greater(swDelayed.ElapsedMilliseconds - epsilon, swUndelayed.ElapsedMilliseconds);
-
-        }
-
-    }
+		public async Task<string> StartDelayedRequest(Stopwatch sw)
+		{
+			using (var wc = new WebClient())
+			{
+				sw.Restart();
+				var ans = await wc.DownloadStringTaskAsync($"{_hostUrl}/firstEndp");
+				sw.Stop();
+				return ans;
+			}
+		}
+	}
 }

--- a/src/HttpMock.Unit.Tests/RequestHandlerTests.cs
+++ b/src/HttpMock.Unit.Tests/RequestHandlerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Kayak.Http;
 using NUnit.Framework;
 
 namespace HttpMock.Unit.Tests
@@ -36,6 +37,22 @@ namespace HttpMock.Unit.Tests
             var uriWithBlah = "http://www.xyz.com/moomins/goncalo";
 
             Assert.That(h.CanVerifyConstraintsFor(uriWithBlah), Is.EqualTo(false));
+        }
+
+        [Test]
+        public void Gets_the_last_request_that_was_handled()
+        {
+	        const string expected = "third";
+
+	        var requestHandler = new RequestHandler("/path", null);
+	        
+	        requestHandler.RecordRequest(new HttpRequestHead(), "first");
+	        requestHandler.RecordRequest(new HttpRequestHead(), "second");
+	        requestHandler.RecordRequest(new HttpRequestHead(), expected);
+	        
+	        var receivedRequest = requestHandler.LastRequest();
+	        
+	        Assert.That(receivedRequest.Body, Is.EqualTo(expected));
         }
     }
 }

--- a/src/HttpMock/RequestHandler.cs
+++ b/src/HttpMock/RequestHandler.cs
@@ -11,7 +11,7 @@ namespace HttpMock
 	{
 		private readonly ResponseBuilder _webResponseBuilder = new ResponseBuilder();
 		private readonly IList<Func<string, bool>> _constraints = new List<Func<string, bool>>();
-		private readonly Queue<ReceivedRequest> _observedRequests = new Queue<ReceivedRequest>();
+		private readonly List<ReceivedRequest> _observedRequests = new List<ReceivedRequest>();
 
 		public RequestHandler(string path, IRequestProcessor requestProcessor) {
 			Path = path;
@@ -118,11 +118,11 @@ namespace HttpMock
 
 		public void RecordRequest(HttpRequestHead request, string body)
 		{
-			_observedRequests.Enqueue(new ReceivedRequest(request, body));
+			_observedRequests.Add(new ReceivedRequest(request, body));
 		}
 
 		public string GetBody() {
-			return _observedRequests.Peek().Body;
+			return _observedRequests.Last().Body;
 		}
 
 		public bool CanVerifyConstraintsFor(string url)
@@ -132,7 +132,7 @@ namespace HttpMock
 
 		public ReceivedRequest LastRequest()
 		{
-			return _observedRequests.Peek();
+			return _observedRequests.Last();
 		}
 		
 		public IEnumerable<ReceivedRequest> GetObservedRequests()


### PR DESCRIPTION
Was using a Queue.Peek to get the last request. Peek returns whats at the beginning of the Queue. 
Changed this to a List.